### PR TITLE
Remove cache seeding and redundant useEffect syncs

### DIFF
--- a/apps/start/src/components/pages/admin/settings/orgId/labels.tsx
+++ b/apps/start/src/components/pages/admin/settings/orgId/labels.tsx
@@ -12,6 +12,7 @@ import { useEffect } from "react";
 export default function SettingsOrganizationLabelsPage() {
 	const { ws } = useLayoutData();
 	const { organization, setOrganization, setCategories, setLabels, tasks, labels } = useLayoutOrganizationSettings();
+	console.log("🚀 ~ SettingsOrganizationLabelsPage ~ labels:", labels)
 	useWebSocketSubscription({
 		ws,
 		orgId: organization.id,

--- a/apps/start/src/contexts/ContextMine.tsx
+++ b/apps/start/src/contexts/ContextMine.tsx
@@ -1,6 +1,6 @@
 import type { schema } from "@repo/database";
 import { useStateManagement } from "@repo/ui/hooks/useStateManagement.ts";
-import { createContext, type ReactNode, useContext, useEffect } from "react";
+import { createContext, type ReactNode, useContext } from "react";
 
 interface ContextType {
 	tasks: schema.TaskWithLabels[];
@@ -37,13 +37,6 @@ export function RootProviderMyTasks({
 	const { value: NewViews, setValue: setViews } = useStateManagement("my-views", views, 30000);
 	const { value: NewCategories, setValue: setCategories } = useStateManagement("my-categories", categories, 30000);
 	const { value: NewReleases, setValue: setReleases } = useStateManagement("my-releases", releases, 30000);
-
-	// Sync props -> state
-	useEffect(() => setTasks(tasks), [tasks, setTasks]);
-	useEffect(() => setLabels(labels), [labels, setLabels]);
-	useEffect(() => setViews(views), [views, setViews]);
-	useEffect(() => setCategories(categories), [categories, setCategories]);
-	useEffect(() => setReleases(releases), [releases, setReleases]);
 
 	return (
 		<MyTasksContext.Provider

--- a/apps/start/src/contexts/ContextOrg.tsx
+++ b/apps/start/src/contexts/ContextOrg.tsx
@@ -2,7 +2,6 @@
 import type { schema } from "@repo/database";
 import { useIsMobile } from "@repo/ui/hooks/use-mobile.tsx";
 import { useStateManagement } from "@repo/ui/hooks/useStateManagement.ts";
-import { useQueryClient } from "@tanstack/react-query";
 import { createContext, type ReactNode, useContext, useEffect } from "react";
 import { useHydration } from "./HydrationContext";
 
@@ -44,19 +43,8 @@ export function RootProviderOrganization({
 	issueTemplates: ContextType["issueTemplates"];
 	releases: ContextType["releases"];
 }) {
-	const queryClient = useQueryClient();
 	const isMobile = useIsMobile();
 	const { isHydrated } = useHydration();
-
-	// Seed cache synchronously BEFORE useStateManagement hooks run
-	// This ensures the first render uses fresh props data, not stale cache
-	// setQueryData is safe to call during render (idempotent)
-	queryClient.setQueryData(["organization"], initialOrganization);
-	queryClient.setQueryData(["labels"], initialLabels);
-	queryClient.setQueryData(["views"], initialViews);
-	queryClient.setQueryData(["categories"], initialCategories);
-	queryClient.setQueryData(["issueTemplates"], initialIssueTemplates);
-	queryClient.setQueryData(["releases"], initialReleases);
 
 	// Use useStateManagement - cache is already seeded above, so it will find the data
 	const { value: organization, setValue: setOrganization } = useStateManagement("organization", initialOrganization, 30000);

--- a/apps/start/src/contexts/ContextOrgSettings.tsx
+++ b/apps/start/src/contexts/ContextOrgSettings.tsx
@@ -44,19 +44,6 @@ export function SettingsProviderOrganization({
 	issueTemplates: ContextType["issueTemplates"];
 	releases: ContextType["releases"];
 }) {
-	const queryClient = useQueryClient();
-
-	// Seed cache synchronously BEFORE useStateManagement hooks run
-	// This ensures the first render uses fresh props data, not stale cache
-	queryClient.setQueryData(["organization"], initialOrganization);
-	queryClient.setQueryData(["labels"], initialLabels);
-	queryClient.setQueryData(["views"], initialViews);
-	queryClient.setQueryData(["categories"], initialCategories);
-	queryClient.setQueryData(["tasks"], initialTasks);
-	queryClient.setQueryData(["issueTemplates"], initialIssueTemplates);
-	queryClient.setQueryData(["releases"], initialReleases);
-
-	// Use useStateManagement - cache is already seeded above, so it will find the data
 	const { value: organization, setValue: setOrganization } = useStateManagement("organization", initialOrganization, 30000);
 	const { value: labels, setValue: setLabels } = useStateManagement("labels", initialLabels, 30000);
 	const { value: views, setValue: setViews } = useStateManagement("views", initialViews, 30000);

--- a/apps/start/src/contexts/ContextOrgTask.tsx
+++ b/apps/start/src/contexts/ContextOrgTask.tsx
@@ -1,7 +1,7 @@
 "use client";
 import type { schema } from "@repo/database";
 import { useStateManagement } from "@repo/ui/hooks/useStateManagement.ts";
-import { createContext, type ReactNode, useContext, useEffect } from "react";
+import { createContext, type ReactNode, useContext } from "react";
 
 interface ContextType {
 	task: schema.TaskWithLabels;
@@ -21,7 +21,6 @@ export function RootProviderOrganizationTask({
 	organization?: ContextType["organization"];
 }) {
 	const { value: newTask, setValue: setTask } = useStateManagement("_task_", task, 1);
-	useEffect(() => setTask(task), [task, setTask]);
 	return <RootContext.Provider value={{ task: newTask, setTask, organization }}>{children}</RootContext.Provider>;
 }
 

--- a/apps/start/src/contexts/ContextOrgTasks.tsx
+++ b/apps/start/src/contexts/ContextOrgTasks.tsx
@@ -1,7 +1,6 @@
 "use client";
 import type { schema } from "@repo/database";
 import { useStateManagement } from "@repo/ui/hooks/useStateManagement.ts";
-import { useQueryClient } from "@tanstack/react-query";
 import { createContext, type ReactNode, useContext } from "react";
 
 interface ContextType {
@@ -21,13 +20,6 @@ export function RootProviderOrganizationTasks({
 	tasks: ContextType["tasks"];
 	organization?: ContextType["organization"];
 }) {
-	const queryClient = useQueryClient();
-
-	// Seed cache synchronously BEFORE useStateManagement hooks run
-	// This ensures the first render uses fresh props data, not stale cache
-	queryClient.setQueryData(["tasks"], initialTasks);
-
-	// Use useStateManagement - cache is already seeded above, so it will find the data
 	const { value: tasks, setValue: setTasks } = useStateManagement("tasks", initialTasks, 30000);
 
 	return <RootContext.Provider value={{ tasks, setTasks, organization }}>{children}</RootContext.Provider>;


### PR DESCRIPTION
Remove synchronous React Query cache seeding (queryClient.setQueryData) from organization-related context providers and drop redundant prop->state useEffect synchronizers. Also remove now-unused imports and add a debug console.log in SettingsOrganizationLabelsPage. Affected files: ContextOrg.tsx, ContextOrgSettings.tsx, ContextOrgTasks.tsx, ContextMine.tsx, ContextOrgTask.tsx, and apps/start/src/components/pages/admin/settings/orgId/labels.tsx. The change relies on useStateManagement to initialize state instead of manual seeding or repeated useEffect updates.