### PR TITLE
Use organizationId in task context; enable reload

### DIFF
--- a/apps/start/src/contexts/ContextOrgTask.tsx
+++ b/apps/start/src/contexts/ContextOrgTask.tsx
@@ -1,7 +1,7 @@
 "use client";
 import type { schema } from "@repo/database";
 import { useStateManagementKey } from "@repo/ui/hooks/useStateManagement.ts";
-import { createContext, type ReactNode, useContext } from "react";
+import { createContext, type ReactNode, useContext, useEffect } from "react";
 
 interface ContextType {
 	task: schema.TaskWithLabels;
@@ -14,14 +14,17 @@ const RootContext = createContext<ContextType | undefined>(undefined);
 export function RootProviderOrganizationTask({
 	children,
 	task,
-	organization,
+	organizationId,
 }: {
 	children: ReactNode;
 	task: ContextType["task"];
-	organization?: ContextType["organization"];
+	organizationId: string;
 }) {
-	const { value: newTask, setValue: setTask } = useStateManagementKey(["_task_", organization?.id || ""], task, 1);
-	return <RootContext.Provider value={{ task: newTask, setTask, organization }}>{children}</RootContext.Provider>;
+	const { value: newTask, setValue: setTask } = useStateManagementKey(["task", task.id, organizationId], task, 1);
+	useEffect(() => {
+		setTask(task)
+	}, [task])
+	return <RootContext.Provider value={{ task: newTask, setTask }}>{children}</RootContext.Provider>;
 }
 
 export function useLayoutTask() {

--- a/apps/start/src/routes/(admin)/$orgId/tasks/$taskShortId/route.tsx
+++ b/apps/start/src/routes/(admin)/$orgId/tasks/$taskShortId/route.tsx
@@ -18,7 +18,7 @@ export const Route = createFileRoute("/(admin)/$orgId/tasks/$taskShortId")({
       },
     });
   },
-  staleTime: 1000 * 60,
+  shouldReload: true,
   component: OrgTasksLayout,
   head: ({ loaderData }) => ({
     meta: seo({
@@ -31,7 +31,7 @@ function OrgTasksLayout() {
   const { task } = Route.useLoaderData();
 
   return (
-    <RootProviderOrganizationTask task={task}>
+    <RootProviderOrganizationTask task={task} organizationId={task.organizationId}>
       <TaskCommandRegistrar />
       <OrganizationTaskIdPage />
     </RootProviderOrganizationTask>


### PR DESCRIPTION
Pass organizationId to the task context and make the state key dependent on task.id and organizationId. Add useEffect to update the managed task value when the incoming task prop changes, and remove the organization object from the provided context value. In the route, replace staleTime with shouldReload: true and pass task.organizationId to RootProviderOrganizationTask so the context key and reload behavior keep task state in sync across orgs. Ref 13