### PR TITLE
Waitlist Docker/CI config and cleanup verbose logging

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -80,6 +80,8 @@ jobs:
           file: ${{ steps.config.outputs.dockerfile }}
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            ${{ matrix.app == 'marketing' && format('PUBLIC_CAP_API_ENDPOINT={0}', secrets.PUBLIC_CAP_API_ENDPOINT) || '' }}
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ steps.config.outputs.image_suffix }},push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest

--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -121,6 +121,8 @@ jobs:
           file: ${{ steps.config.outputs.dockerfile }}
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            ${{ matrix.app == 'marketing' && format('PUBLIC_CAP_API_ENDPOINT={0}', secrets.PUBLIC_CAP_API_ENDPOINT) || '' }}
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ steps.config.outputs.image_suffix }},push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest

--- a/apps/backend/routes/api/internal/v1/index.ts
+++ b/apps/backend/routes/api/internal/v1/index.ts
@@ -14,7 +14,6 @@ internalApiV1.route("/console", apiRouteConsole);
 internalApiV1.post("/waitlist", async (c) => {
     try {
         const { email, captchaToken } = await c.req.json();
-        console.log("[waitlist] Received request for email:", email);
         if (!email) {
             return c.json({ error: "Email is required" }, 400);
         }
@@ -27,17 +26,14 @@ internalApiV1.post("/waitlist", async (c) => {
             return c.json({ error: "Server misconfigured" }, 500);
         }
         if (!captchaToken) {
-            console.log("[waitlist] Missing captcha token");
             return c.json({ error: "Captcha verification required" }, 400);
         }
-        console.log("[waitlist] Verifying captcha token");
         const capRes = await fetch(`${capApiEndpoint}/siteverify`, {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({ secret: capSecret, response: captchaToken }),
         });
         const capData = await capRes.json() as { success: boolean };
-        console.log("[waitlist] Captcha verify result:", capData);
         if (!capData.success) {
             return c.json({ error: "Captcha verification failed" }, 403);
         }
@@ -45,30 +41,16 @@ internalApiV1.post("/waitlist", async (c) => {
         const bookId = process.env.SAYR_WAITLIST_BOOK_ID;
         const templateId = process.env.SAYR_WAITLIST_TEMPLATE_ID;
         const fromEmail = process.env.SAYR_FROM_EMAIL;
-        console.log("[waitlist] Config check:", {
-            hasApiKey: !!apiKey,
-            hasBookId: !!bookId,
-            hasTemplateId: !!templateId,
-            hasFromEmail: !!fromEmail,
-            bookId,
-            templateId,
-            fromEmail,
-        });
         if (!apiKey || !bookId || !templateId || !fromEmail) {
             console.error("[waitlist] Missing waitlist env configuration");
             return c.json({ error: "Server misconfigured" }, 500);
         }
         const usesend = new UseSend(apiKey);
         const normalizedEmail = email.toLowerCase().trim();
-        console.log("[waitlist] Checking if contact exists:", normalizedEmail);
         const existing = await checkUsesendContactExists(apiKey, bookId, normalizedEmail);
-        console.log("[waitlist] Contact exists:", existing);
         if (existing) {
             // Allow @doras.to emails to bypass duplicate check for testing
-            if (normalizedEmail.endsWith("@doras.to")) {
-                console.log("[waitlist] Contact exists but @doras.to domain, skipping duplicate check for testing");
-            } else {
-                console.log("[waitlist] Contact already exists, returning 409");
+            if (!normalizedEmail.endsWith("@doras.to")) {
                 return c.json(
                     {
                         message: "Successfully added to waitlist",
@@ -78,22 +60,18 @@ internalApiV1.post("/waitlist", async (c) => {
             }
         }
         // Add to contact book
-        console.log("[waitlist] Creating contact in book:", bookId);
-        const createResult = await usesend.contacts.create(bookId, {
+        await usesend.contacts.create(bookId, {
             email: normalizedEmail,
         });
-        console.log("[waitlist] Contact create result:", createResult);
         // Brief delay to avoid UseSend rate limiting between sequential API calls
         await new Promise((resolve) => setTimeout(resolve, 1500));
         // Send confirmation email
-        console.log("[waitlist] Sending email with templateId:", templateId, "from:", fromEmail);
-        const emailResult = await usesend.emails.send({
+        await usesend.emails.send({
             to: normalizedEmail,
             templateId,
             from: `Sayr.io <${fromEmail}>`,
             text: "Sayr.io waitlist confirmation",
         });
-        console.log("[waitlist] Email send result:", emailResult);
         return c.json({
             message: "Successfully added to waitlist",
         });

--- a/apps/marketing/Dockerfile
+++ b/apps/marketing/Dockerfile
@@ -29,6 +29,10 @@ COPY --from=builder /app/out/full/ .
 
 RUN pnpm install
 
+# Astro inlines PUBLIC_* env vars at build time, so they must be available here
+ARG PUBLIC_CAP_API_ENDPOINT
+ENV PUBLIC_CAP_API_ENDPOINT=${PUBLIC_CAP_API_ENDPOINT}
+
 # Build the application
 RUN cd apps/marketing && pnpm run build
 
@@ -42,6 +46,7 @@ RUN adduser --system --uid 1001 astro
 ENV HOST=0.0.0.0
 ENV PORT=8080
 ENV NODE_ENV=production
+ENV BACKEND_URL=http://sayr-backend:5468
 
 # Copy the entire workspace structure to preserve pnpm symlinks
 COPY --from=installer --chown=astro:nodejs /app/node_modules ./node_modules

--- a/docker/cloud/compose.yml
+++ b/docker/cloud/compose.yml
@@ -74,12 +74,19 @@ services:
       - AXIOM_OTEL_DATASET=${AXIOM_OTEL_DATASET}
       - SAYR_CLOUD=${SAYR_CLOUD}
       - APP_ENV=${APP_ENV}
+      - CAP_API_ENDPOINT=${CAP_API_ENDPOINT}
+      - CAP_SECRET_KEY=${CAP_SECRET_KEY}
+      - SAYR_WAITLIST_BOOK_ID=${SAYR_WAITLIST_BOOK_ID}
+      - SAYR_WAITLIST_TEMPLATE_ID=${SAYR_WAITLIST_TEMPLATE_ID}
+      - SAYR_FROM_EMAIL=${SAYR_FROM_EMAIL}
 
   marketing:
     container_name: sayr-marketing
     image: ghcr.io/dorasto/sayr-marketing:latest
     restart: always
     pull_policy: always
+    environment:
+      - BACKEND_URL=http://sayr-backend:5468
 
   github-worker:
     container_name: sayr-worker-github


### PR DESCRIPTION
## Release Notes

### Improvements
- Removed all verbose `console.log` debug statements from the waitlist endpoint, keeping only `console.error` for actual error conditions (missing env config, caught exceptions)
- Simplified the `@doras.to` duplicate bypass logic from an if/else to a single negated condition
- Removed unused `createResult` and `emailResult` variables from UseSend API calls

### Infrastructure
- Added `PUBLIC_CAP_API_ENDPOINT` as a Docker build arg in the marketing Dockerfile so Astro can inline it at build time
- Added `BACKEND_URL` runtime env var to the marketing Dockerfile runner stage (defaults to `http://sayr-backend:5468` for Docker networking)
- Added waitlist and captcha env vars to the backend service in `compose.yml`: `CAP_API_ENDPOINT`, `CAP_SECRET_KEY`, `SAYR_WAITLIST_BOOK_ID`, `SAYR_WAITLIST_TEMPLATE_ID`, `SAYR_FROM_EMAIL`
- Added `BACKEND_URL` env var to the marketing service in `compose.yml`
- Updated both CI workflows (`build-and-deploy.yml`, `manual-build.yml`) to pass `PUBLIC_CAP_API_ENDPOINT` from GitHub secrets as a build arg when building the marketing image

## Summary

Production-readies the waitlist feature by adding all required environment variables to Docker and CI configuration, and cleans up debug logging that was used during development. The `PUBLIC_CAP_API_ENDPOINT` secret must be added to the GitHub repository settings before the next build.

## Technical Details

**Dockerfile (`apps/marketing/Dockerfile`)**:
- `ARG PUBLIC_CAP_API_ENDPOINT` + `ENV` set in the `installer` stage before `pnpm run build` — Astro inlines `PUBLIC_*` vars at build time
- `ENV BACKEND_URL=http://sayr-backend:5468` in the `runner` stage — used by the Astro server-side API proxy route at runtime

**CI Workflows**: Both workflows conditionally pass `build-args` only for the `marketing` matrix entry using `${{ matrix.app == 'marketing' && format(...) || '' }}` to avoid affecting other app builds.

**Backend logging cleanup**: Removed 12 `console.log` statements. Retained `console.error` at `index.ts:25` (missing CAP config), `index.ts:45` (missing waitlist config), and `index.ts:81` (caught exception) — these are meaningful error signals worth preserving in production logs.

### Required secrets/env vars before deploy
| Variable | Where | Purpose |
|---|---|---|
| `PUBLIC_CAP_API_ENDPOINT` | GitHub repo secret | Cap.js URL, passed as Docker build arg for marketing |
| `CAP_API_ENDPOINT` | Coolify/deploy env | Cap.js URL for backend server-side verification |
| `CAP_SECRET_KEY` | Coolify/deploy env | Cap.js secret key |
| `SAYR_WAITLIST_BOOK_ID` | Coolify/deploy env | UseSend contact book ID |
| `SAYR_WAITLIST_TEMPLATE_ID` | Coolify/deploy env | UseSend email template ID |
| `SAYR_FROM_EMAIL` | Coolify/deploy env | Sender email address |

## File Changes
| File | Change |
|---|---|
| `.github/workflows/build-and-deploy.yml` | Added `build-args` for marketing Docker build |
| `.github/workflows/manual-build.yml` | Added `build-args` for marketing Docker build |
| `apps/backend/routes/api/internal/v1/index.ts` | Removed verbose logging, simplified doras.to bypass, removed unused vars |
| `apps/marketing/Dockerfile` | Added `PUBLIC_CAP_API_ENDPOINT` build arg + `BACKEND_URL` runtime env |
| `docker/cloud/compose.yml` | Added waitlist/captcha env vars to backend, `BACKEND_URL` to marketing |