### PR TITLE
Fix Dockerfile migration command for production builds

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -72,5 +72,8 @@ ENV APP_ENV="production"
 # Expose the port the app runs on
 EXPOSE 5468
 
-# Run Drizzle migrations first, then start backend
-CMD ["bun", "-c", "pnpm --filter @repo/database migrate && bun run dist/index.js"]
+COPY --from=installer /app/packages/database ./packages/database
+COPY --from=installer /app/node_modules/drizzle-kit ./node_modules/drizzle-kit
+
+# Run Drizzle migrations from packages/database, then start backend
+CMD ["sh", "-c", "cd packages/database && bun run migrate && cd ../.. && bun run dist/index.js"]


### PR DESCRIPTION
## Release Notes

### Bug Fixes
- Fixed Dockerfile to properly run Drizzle migrations from the packages/database directory
- The previous command failed because it tried to run migrate from the wrong location

### Technical Details
The migration command was failing in Docker because:
- Previous approach used `pnpm --filter @repo/database migrate` which didn't work in the final container
- Now copies `packages/database` and `drizzle-kit` to the final image
- Runs migrations with `cd packages/database && bun run migrate` before starting the backend

Changed files:
- `apps/backend/Dockerfile`: Updated COPY and CMD instructions for migrations