### PR TITLE
Fix typo in user export endpoint Redis URL check

### DIFF
--- a/apps/backend/routes/api/internal/v1/user.ts
+++ b/apps/backend/routes/api/internal/v1/user.ts
@@ -243,7 +243,7 @@ apiRouteAdminUser.get("/export", async (c) => {
 	if (!session?.userId) {
 		return c.json({ success: false, error: "UNAUTHORIZED" }, 401);
 	}
-	if (!process.env.REDIS_UR) {
+	if (!process.env.REDIS_URL) {
 		return c.json(
 			{
 				success: false,


### PR DESCRIPTION
## Release Notes

### Bug Fixes
- Fixed typo in user export endpoint that referenced `REDIS_UR` instead of `REDIS_URL` environment variable

## Summary
Fixed a typo in the GDPR export endpoint that caused the Redis URL environment variable check to always fail due to a truncated variable name.

## Technical Details
The `/api/admin/v1/user/export` endpoint had a truncated environment variable reference (`REDIS_UR`) that was missing the final `L` to properly check for `REDIS_URL`.

**File changed:** `apps/backend/routes/api/internal/v1/user.ts:246`
