### PR TITLE
Fix passkey auto-sign-in and enable email input on login page

### DIFF
--- a/apps/start/src/components/auth/login.tsx
+++ b/apps/start/src/components/auth/login.tsx
@@ -93,15 +93,19 @@ export function LoginComponent({
     setLastMethod(authClient.getLastUsedLoginMethod());
   }, []);
   useEffect(() => {
-    if (!PublicKeyCredential.isConditionalMediationAvailable ||
-      !PublicKeyCredential.isConditionalMediationAvailable()) {
-      return;
-    }
-    authClient.signIn.passkey().then(e => {
-      if (e.data?.session) {
-        signInEmail();
+    void (async () => {
+      if (
+        typeof PublicKeyCredential === "undefined" ||
+        typeof PublicKeyCredential.isConditionalMediationAvailable !== "function" ||
+        !(await PublicKeyCredential.isConditionalMediationAvailable())
+      ) {
+        return;
       }
-    })
+      const result = await authClient.signIn.passkey();
+      if (result.data?.session) {
+        await signInEmail();
+      }
+    })();
   }, [])
   const handleEmailSubmit = () => {
     if (email) {


### PR DESCRIPTION
## Release Notes

### Bug Fixes
- Fixed passkey auto-sign-in not triggering on page load
- Enabled the email input field which was previously disabled

### Improvements
- Added proper `autoComplete` attributes to email and password fields for better browser autofill support
- Refactored `lastMethod` to use React state with proper initialization

## Summary
Fixed passkey auto-sign-in functionality on the login page and enabled the email input field. The login page now properly attempts passkey authentication on page load and provides better autocomplete support for password managers.

## Technical Details
- Changed `lastMethod` from a direct function call to React state with useEffect initialization to ensure proper reactivity
- Added a useEffect that checks for `ConditionalMediationAvailable` and automatically triggers passkey sign-in
- Updated email input: removed `disabled` attribute and changed autoComplete from `"webauthn"` to `"email webauthn"`
- Added `autoComplete="password"` to the password input field

Files changed:
- `apps/start/src/components/auth/login.tsx`