### PR TITLE
Discord bot: Support multiple organizations per guild with org selector

### DIFF
--- a/integrations/services/discordbot/api/index.ts
+++ b/integrations/services/discordbot/api/index.ts
@@ -80,17 +80,15 @@ apiRoute.patch("/settings", async (c) => {
 	}
 
 	if (body.guildId !== undefined) {
-		const ownerOrg = await getGuildOwner(INTEGRATION_ID, body.guildId)
-
-		if (ownerOrg && ownerOrg !== orgId) {
-			return c.json({ error: "Guild already in use" }, 400)
-		}
-
 		updated.guildId = body.guildId // safe for snowflakes
 	}
 
 	if (body.channelId !== undefined) {
 		updated.channelId = body.channelId // safe for snowflakes
+	}
+
+	if (body.orgName !== undefined) {
+		updated.orgName = body.orgName;
 	}
 
 	// Save once

--- a/integrations/services/discordbot/src/commands/create.ts
+++ b/integrations/services/discordbot/src/commands/create.ts
@@ -1,4 +1,4 @@
-import { getIntegrationConfigByValue, getIntegrationStorage } from "@repo/database";
+import { getIntegrationConfigByValue, getIntegrationConfigsByValue, getIntegrationStorage } from "@repo/database";
 
 import {
 	SlashCommandSubcommandBuilder,
@@ -27,17 +27,40 @@ export const data = (sub: SlashCommandSubcommandBuilder) =>
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
 async function getOrgAndTemplates(guildId: string | null) {
-	if (!guildId) return null;
+	if (!guildId) return [];
 
-	const settings = await getIntegrationConfigByValue<integrationConfigValueType>("settings", "discordbot", "guildId", guildId)
-	if (!settings) return null;
-	if (!settings?.value?.enabled) return null;
+	const settingsList =
+		await getIntegrationConfigsByValue<integrationConfigValueType>(
+			"settings",
+			"discordbot",
+			"guildId",
+			guildId
+		);
 
-	const storage = await getIntegrationStorage(settings.organizationId, "discordbot");
-	const storageData = (storage?.data ?? {}) as Record<string, unknown>;
-	const templates = (storageData.templates ?? []) as DiscordTemplate[];
+	if (settingsList.length === 0) return [];
 
-	return { settings, templates };
+	const enabledSettings = settingsList.filter(
+		(s) => s.value?.enabled
+	);
+
+	const results: Array<{
+		settings: typeof enabledSettings[number];
+		templates: DiscordTemplate[];
+	}> = [];
+
+	for (const settings of enabledSettings) {
+		const storage = await getIntegrationStorage(
+			settings.organizationId,
+			"discordbot"
+		);
+
+		const storageData = (storage?.data ?? {}) as Record<string, unknown>;
+		const templates = (storageData.templates ?? []) as DiscordTemplate[];
+
+		results.push({ settings, templates });
+	}
+
+	return results;
 }
 
 function buildModal(template: DiscordTemplate) {
@@ -93,7 +116,7 @@ export async function execute(interaction: ChatInputCommandInteraction) {
 		return;
 	}
 
-	const { templates } = result;
+	const templates = result.flatMap((r) => r.templates);
 
 	if (templates.length === 0) {
 		await interaction.reply({
@@ -108,21 +131,49 @@ export async function execute(interaction: ChatInputCommandInteraction) {
 		await interaction.showModal(buildModal(templates[0]!));
 		return;
 	}
+	if (result.length > 1) {
+		const orgSelect = new StringSelectMenuBuilder()
+			.setCustomId("sayr-org-select")
+			.setPlaceholder("Choose an organisation...")
+			.addOptions(
+				result.map((org) => {
+					return new StringSelectMenuOptionBuilder()
+						.setLabel(org.settings.value.orgName || "")
+						.setValue(org.settings.organizationId)
+						.setDescription("Select this organisation");
+				})
+			);
+
+		const orgRow =
+			new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(orgSelect);
+
+		await interaction.reply({
+			content: "Select an organisation:",
+			components: [orgRow],
+			flags: MessageFlags.Ephemeral,
+		});
+		return;
+	}
 
 	// Multiple templates — show a select menu first
 	const select = new StringSelectMenuBuilder()
 		.setCustomId("sayr-template-select")
 		.setPlaceholder("Choose a template...")
 		.addOptions(
-			templates.map((t) =>
-				new StringSelectMenuOptionBuilder()
-					.setLabel(t.name)
+			templates.map((t) => {
+				return new StringSelectMenuOptionBuilder()
+					.setLabel(`${t.name}`)
 					.setValue(t.id)
 					.setDescription(
-						t.description
-							? t.description.slice(0, 100)
-							: `Status: ${t.defaults.status} | Priority: ${t.defaults.priority}`,
-					),
+						[
+							t.description
+								? t.description.slice(0, 100)
+								: `Status: ${t.defaults.status} | Priority: ${t.defaults.priority}`
+						]
+							.filter(Boolean)
+							.join(" • ")
+					)
+			}
 			),
 		);
 
@@ -155,8 +206,9 @@ export function registerModalHandler(client: Client) {
 			});
 			return;
 		}
+		const allTemplates = result.flatMap((r) => r.templates);
 
-		const template = result.templates.find((t) => t.id === templateId);
+		const template = allTemplates.find((t) => t.id === templateId);
 		if (!template) {
 			await menuInteraction.reply({
 				content: "Template not found. It may have been deleted.",
@@ -166,6 +218,75 @@ export function registerModalHandler(client: Client) {
 		}
 
 		await menuInteraction.showModal(buildModal(template));
+	});
+
+	client.on(Events.InteractionCreate, async (interaction) => {
+		if (!interaction.isStringSelectMenu()) return;
+		if (interaction.customId !== "sayr-org-select") return;
+
+		const menuInteraction = interaction as StringSelectMenuInteraction;
+		const orgId = menuInteraction.values[0];
+		if (!orgId) return;
+
+		const result = await getOrgAndTemplates(menuInteraction.guildId);
+		if (!result) {
+			await menuInteraction.reply({
+				content: "This integration is not enabled.",
+				flags: MessageFlags.Ephemeral
+			});
+			return;
+		}
+
+		// find org entry
+		const orgEntry = result.find((r) => r.settings.organizationId === orgId);
+		if (!orgEntry) {
+			await menuInteraction.reply({
+				content: "Org not found.",
+				flags: MessageFlags.Ephemeral
+			});
+			return;
+		}
+
+		const templates = orgEntry.templates;
+
+		// If only one template → jump straight to modal
+		if (templates.length === 1) {
+			await menuInteraction.showModal(buildModal(templates[0]!));
+			return;
+		}
+
+		// Build template select for this org
+		const select = new StringSelectMenuBuilder()
+			.setCustomId("sayr-template-select")
+			.setPlaceholder("Choose a template...")
+			.addOptions(
+				templates.map((t) => {
+					return new StringSelectMenuOptionBuilder()
+						.setLabel(t.name)
+						.setValue(t.id)
+						.setDescription(
+							[
+								orgEntry.settings.value.orgName
+									? `Org: ${orgEntry.settings.value.orgName}`
+									: null,
+								t.description
+									? t.description.slice(0, 100)
+									: `Status: ${t.defaults.status} | Priority: ${t.defaults.priority}`
+							]
+								.filter(Boolean)
+								.join(" • ")
+						);
+				})
+			);
+
+		const row =
+			new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select);
+
+		await menuInteraction.reply({
+			content: "Select a template to use:",
+			components: [row],
+			flags: MessageFlags.Ephemeral
+		});
 	});
 
 	// Handle modal submit
@@ -184,10 +305,14 @@ export function registerModalHandler(client: Client) {
 			return;
 		}
 
-		const { settings, templates } = result;
-		const template = templates.find((t) => t.id === templateId);
+		const match = result.find((r) =>
+			r.templates.some((t) => t.id === templateId)
+		);
 
-		if (!template) {
+		const template = match?.templates.find((t) => t.id === templateId);
+		const settings = match?.settings;
+
+		if (!template || !settings) {
 			await interaction.reply({
 				content: "Template not found. It may have been deleted. Please run /sayr create again.",
 				flags: MessageFlags.Ephemeral,

--- a/integrations/services/discordbot/src/commands/create.ts
+++ b/integrations/services/discordbot/src/commands/create.ts
@@ -1,4 +1,4 @@
-import { getIntegrationConfigByValue, getIntegrationConfigsByValue, getIntegrationStorage } from "@repo/database";
+import { getIntegrationConfigsByValue, getIntegrationStorage } from "@repo/database";
 
 import {
 	SlashCommandSubcommandBuilder,

--- a/integrations/services/discordbot/src/types/index.ts
+++ b/integrations/services/discordbot/src/types/index.ts
@@ -2,4 +2,5 @@ export interface integrationConfigValueType {
     guildId?: string;
     channelId?: string;
     enabled?: boolean;
+    orgName?: string;
 }

--- a/integrations/services/discordbot/ui/pages.ts
+++ b/integrations/services/discordbot/ui/pages.ts
@@ -32,6 +32,13 @@ export const settingsPage: UIPage = {
           description: "Channel to send notifications to by default",
           placeholder: "123456789012345678",
         },
+        {
+          name: "orgName",
+          type: "string",
+          label: "Organisation Name",
+          description: "A friendly name used to identify this organisation",
+          placeholder: "Acme Corp",
+        }
       ],
       actions: [
         {

--- a/packages/database/src/functions/integrations.ts
+++ b/packages/database/src/functions/integrations.ts
@@ -62,6 +62,34 @@ export async function getIntegrationConfigByValue<TValue = unknown>(
 	}
 }
 
+export async function getIntegrationConfigsByValue<TValue = unknown>(
+	key: string,
+	integrationId: string,
+	valueKey: string,
+	value: string
+): Promise<Array<Omit<integrationConfigType, "value"> & { value: TValue }>> {
+	const result = await db
+		.select()
+		.from(integrationConfig)
+		.where(
+			and(
+				eq(integrationConfig.integrationId, integrationId),
+				eq(integrationConfig.key, key),
+				sql`${integrationConfig.value} ->> ${valueKey} = ${value}`
+			)
+		);
+
+	if (!result.length) return [];
+
+	return result.map((row) => {
+		const base = row as integrationConfigType;
+		return {
+			...base,
+			value: base.value as TValue
+		};
+	});
+}
+
 export async function setIntegrationConfig<TValue = unknown>(
 	orgId: string,
 	integrationId: string,


### PR DESCRIPTION
## Release Notes

### New Features
- Added support for multiple organizations linking the same Discord guild
- New `orgName` field in integration settings to identify organizations in Discord
- Organization selector in `/sayr create` command when multiple organizations share the same guild

### Improvements
- Removed exclusive guild-owner check that prevented multiple orgs from using the same guild
- Created `getIntegrationConfigsByValue` database function to query all integration configs matching a JSON value
- Updated template selection to work across multiple organization entries

### Technical Changes
- Modified `integrations/services/discordbot/api/index.ts` - removed guild ownership check, added `orgName` persistence
- Modified `integrations/services/discordbot/src/commands/create.ts` - added multi-org lookup and selection flow
- Modified `integrations/services/discordbot/src/types/index.ts` - added `orgName` to config type
- Modified `integrations/services/discordbot/ui/pages.ts` - added orgName field to settings UI
- Modified `packages/database/src/functions/integrations.ts` - added `getIntegrationConfigsByValue` function

## Summary
Enabled multiple organizations to use the same Discord guild by removing the exclusive guild-owner check and adding an organization selector in the `/sayr create` command flow.

## Technical Details
- `getIntegrationConfigsByValue` queries the `integrationConfig` table using SQL JSON path matching to find all configs with a specific value in their JSON `value` field
- The `/sayr create` command now first fetches all organizations that have the guild linked, and if multiple exist, presents a selection menu before template selection
- The `orgName` field is persisted via the API settings patch and displayed in the UI for user-friendly organization identification