### PR TITLE
Default PostHog host to EU

### DIFF
--- a/apps/start/vite.config.ts
+++ b/apps/start/vite.config.ts
@@ -97,7 +97,9 @@ const config = defineConfig({
       posthog({
         personalApiKey: process.env.POSTHOG_CLI_TOKEN,
         projectId: process.env.POSTHOG_CLI_ENV_ID || "",
-        host: process.env.VITE_PUBLIC_POSTHOG_HOST || "https://us.i.posthog.com",
+        host: process.env.VITE_PUBLIC_POSTHOG_HOST?.startsWith("http")
+          ? process.env.VITE_PUBLIC_POSTHOG_HOST
+          : "https://eu.i.posthog.com",
         sourcemaps: {
           enabled: true,
           releaseName: "sayr-start",

--- a/zerops.yml
+++ b/zerops.yml
@@ -88,12 +88,10 @@ zerops:
         # These VITE_* / define vars are baked into the bundle at build time (see vite.config.ts)
         APP_ENV: production
         SAYR_EDITION: cloud
-        # PostHog: baked into the client bundle at build time
-        VITE_PUBLIC_POSTHOG_KEY: ${VITE_PUBLIC_POSTHOG_KEY}
-        VITE_PUBLIC_POSTHOG_HOST: ${VITE_PUBLIC_POSTHOG_HOST}
-        # PostHog CLI: POSTHOG_CLI_TOKEN and POSTHOG_CLI_ENV_ID are defined as project-level
-        # custom environment variables in Zerops and are injected automatically — do NOT
-        # redeclare them here or Zerops will create a recursive self-reference loop.
+        # PostHog: VITE_PUBLIC_POSTHOG_KEY, VITE_PUBLIC_POSTHOG_HOST, POSTHOG_CLI_TOKEN, and
+        # POSTHOG_CLI_ENV_ID are defined as project-level custom environment variables in Zerops
+        # and are injected automatically — do NOT redeclare them here or Zerops will create a
+        # recursive self-reference loop.
       prepareCommands:
         # corepack ships with Node.js 22 — use it instead of npm install -g pnpm
         - corepack enable && corepack prepare pnpm@latest --activate


### PR DESCRIPTION
Use VITE_PUBLIC_POSTHOG_HOST only when it starts with http; otherwise fall back to https://eu.i.posthog.com for client bundles

Clarify zerops.yml comment that PostHog variables are provided at the project level (VITE_PUBLIC_POSTHOG_KEY, VITE_PUBLIC_POSTHOG_HOST, POSTHOG_CLI_TOKEN, POSTHOG_CLI_ENV_ID) and must not be redeclared to avoid recursive injection loops