### PR TITLE
Prevent private tasks from syncing to GitHub

### DIFF
--- a/.opencode/update-pr.sh
+++ b/.opencode/update-pr.sh
@@ -33,4 +33,4 @@ fi
 echo "📦 current branch: $branch"
 prompt="use update-pr to update this PR https://github.com/dorasto/sayr/pull/$PR_number"
 echo $prompt
-opencode -m "opencode/minimax-m2.5-free" --prompt "$prompt"
+opencode -m "opencode/qwen3.6-plus" --prompt "$prompt"

--- a/apps/backend/routes/api/internal/v1/task.ts
+++ b/apps/backend/routes/api/internal/v1/task.ts
@@ -315,6 +315,7 @@ apiRouteAdminProjectTask.post("/create", async (c) => {
 				where: eq(schema.organization.id, orgId),
 			});
 			if (!org || !taskWithData) return;
+			if (visible === "private") return;
 			const sayrTaskUrl = `https://${org.slug}.${process.env.VITE_ROOT_DOMAIN}/${taskWithData.shortId}`;
 			const token = await getInstallationToken(foundLink.installationId);
 			const octokit = new Octokit({ auth: token });


### PR DESCRIPTION
## Release Notes

### Bug Fixes
- Private tasks are no longer synchronized or announced to GitHub when created. Previously, all tasks including private ones would trigger GitHub issue creation and external URL building, potentially exposing private work items. The only information that would have been visible is titles of tasks. Body content/comments/etc are not affected.

## Summary

Prevented private tasks from being shared externally by adding an early return in the task creation route when visibility is set to 'private'. This ensures private tasks remain private and are never posted to GitHub repositories.

## Technical Details

Added a visibility check (`if (visible === "private") return;`) in the GitHub issue creation flow within the task creation route. This early return:

- Skips building the external task URL
- Prevents Octokit invocation for GitHub API calls
- Avoids any external synchronization for private tasks

**File changed:** `apps/backend/routes/api/internal/v1/task.ts:318`

The check is placed after fetching the organization and task data but before any external API calls, ensuring minimal overhead and clean separation between private and public task workflows.