### PR TITLE
Use externalCustomerId and camelCase for LLM metadata

### DIFF
--- a/apps/backend/routes/api/internal/v1/ai/summarize-task.ts
+++ b/apps/backend/routes/api/internal/v1/ai/summarize-task.ts
@@ -476,16 +476,16 @@ summarizeTaskRoute.post("/", async (c) => {
 							events: [
 								{
 									name: "ai.task_summary",
-									customerId: polarCustomerId,
+									externalCustomerId: polarCustomerId,
 									metadata: {
-										_cost: { amount: costCents, currency: "usd" } as any,
+										_cost: { amount: costCents, currency: "usd" },
 										_llm: {
 											vendor: "mistral",
 											model: activeModel,
-											input_tokens: promptTokens,
-											output_tokens: completionTokens,
-											total_tokens: totalTokens,
-										} as any,
+											inputTokens: promptTokens,
+											outputTokens: completionTokens,
+											totalTokens: totalTokens,
+										},
 										org_id: orgId,
 										task_id: taskId,
 										task_url: `https://${orgSlug}.${process.env.VITE_ROOT_DOMAIN}/${task.shortId}`,


### PR DESCRIPTION
This pull request updates the event metadata structure sent in the `ai.task_summary` event to improve naming consistency and type safety. The changes mainly focus on renaming properties to follow camelCase conventions and removing unnecessary type assertions.

**Event metadata improvements:**

* Changed the `customerId` property to `externalCustomerId` in the event object for clarity and consistency.
* Updated the `_llm` metadata fields to use camelCase (`inputTokens`, `outputTokens`, `totalTokens`) instead of snake_case, and removed unnecessary `as any` type assertions.
* Simplified the `_cost` metadata by removing the `as any` type assertion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Chores**
  * Updated internal event metadata structure for improved tracking and consistency in AI cost calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->