### PR TITLE
Fixes some rendering issues on the list view on admin

### DIFF
--- a/apps/backend/routes/api/internal/v1/ai/recommendations.ts
+++ b/apps/backend/routes/api/internal/v1/ai/recommendations.ts
@@ -8,6 +8,7 @@ import {
 	getReleases,
 	getTaskById,
 	getTaskLabelCategorySummaries,
+	getTaskTimeline,
 	type schema,
 	searchTasksByOrganization,
 } from "@repo/database";
@@ -17,6 +18,7 @@ import { Hono } from "hono";
 import { z } from "zod";
 import type { AppEnv } from "@/index";
 import { checkAiFeatureAccess } from "../../../../../lib/ai/gate";
+import { buildTimelineLine } from "../../../../../lib/ai/format-timeline";
 import { runAiStructuredFeature } from "../../../../../lib/ai/structured-runner";
 import { errorResponse } from "../../../../../responses";
 
@@ -52,6 +54,11 @@ const requestSchema = z.object({
 	forceRefresh: z.boolean().optional(),
 });
 
+interface RecommendedStatus {
+	value: "in-progress" | "done";
+	reason: string;
+}
+
 interface RecommendationsResult {
 	labelIds: string[];
 	assigneeIds: string[];
@@ -59,13 +66,96 @@ interface RecommendationsResult {
 	categoryId: string | null;
 	releaseId: string | null;
 	relations: { taskId: string; type: string; title: string; shortId: number | null }[];
+	status: RecommendedStatus | null;
 	reasoning?: string;
 	systemPrompt?: string;
 	userPrompt?: string;
 }
 
 function emptyResult(): RecommendationsResult {
-	return { labelIds: [], assigneeIds: [], priority: null, categoryId: null, releaseId: null, relations: [] };
+	return {
+		labelIds: [],
+		assigneeIds: [],
+		priority: null,
+		categoryId: null,
+		releaseId: null,
+		relations: [],
+		status: null,
+	};
+}
+
+/**
+ * GitHub timeline events that count as "work has actually started" signal —
+ * everything except an unlink (see the `github_branch_linked` special-case
+ * below, which only counts a *link*, not a branch being removed).
+ */
+const IN_PROGRESS_SIGNAL_EVENTS = new Set<schema.taskTimelineType["eventType"]>([
+	"github_branch_linked",
+	"github_pr_linked",
+	"github_pr_commit",
+	"github_commit_ref",
+	"task_mentioned",
+]);
+
+function isInProgressSignal(item: Awaited<ReturnType<typeof getTaskTimeline>>[number]): boolean {
+	if (!IN_PROGRESS_SIGNAL_EVENTS.has(item.eventType)) return false;
+	if (item.eventType === "github_branch_linked") {
+		const d = item.toValue as { branch?: { deleted?: boolean } } | null;
+		return !d?.branch?.deleted;
+	}
+	return true;
+}
+
+function isPrMergedSignal(item: Awaited<ReturnType<typeof getTaskTimeline>>[number]): boolean {
+	if (item.eventType !== "github_pr_merged") return false;
+	const d = item.toValue as { pullRequest?: { merged?: boolean } } | null;
+	return d?.pullRequest?.merged !== false;
+}
+
+/**
+ * Deterministic, rule-based status suggestion — not the LLM's job. Whether a
+ * branch got linked, a commit landed, or a PR merged is a fact already
+ * sitting in `taskTimeline`/`githubPullRequest`, not something worth
+ * spending a model call (or risking a hallucinated "yes") to re-derive from
+ * prose. Only ever looks at tasks sitting in a status where GitHub activity
+ * is actually informative: backlog/todo → in-progress (work started
+ * somewhere but the status hasn't caught up), todo/in-progress → done (the
+ * linked PR merged).
+ */
+async function computeStatusSuggestion(
+	orgId: string,
+	taskId: string,
+	task: NonNullable<Awaited<ReturnType<typeof getTaskById>>>
+): Promise<RecommendedStatus | null> {
+	const suggestsInProgress = task.status === "backlog" || task.status === "todo";
+	const suggestsDone = task.status === "todo" || task.status === "in-progress";
+	if (!suggestsInProgress && !suggestsDone) return null;
+
+	// Cheap out on the "done" case when the task's directly linked PR is
+	// already known to be merged — no need to touch the timeline at all.
+	if (suggestsDone && task.githubPullRequest?.merged) {
+		const pr = task.githubPullRequest;
+		return { value: "done", reason: `Linked PR #${pr.prNumber} ("${pr.title}") was merged` };
+	}
+
+	const timeline = await getTaskTimeline(orgId, taskId);
+	const labelMap = new Map<string, string>();
+	const assigneeMap = new Map<string, string>();
+	// Timeline is oldest → newest; walk newest-first so the reported reason
+	// is the most recent signal, not the first one that ever happened.
+	const reversed = [...timeline].reverse();
+
+	if (suggestsDone) {
+		const merged = reversed.find(isPrMergedSignal);
+		if (merged) return { value: "done", reason: buildTimelineLine(merged, labelMap, assigneeMap) };
+	}
+
+	if (suggestsInProgress) {
+		const activity = reversed.find(isInProgressSignal);
+		if (activity) return { value: "in-progress", reason: buildTimelineLine(activity, labelMap, assigneeMap) };
+	}
+
+	return null;
 }
 
 const STOPWORDS = new Set([
@@ -175,6 +265,7 @@ recommendationsRoute.post("/", async (c) => {
 		category: isAiFeatureEnabled(access.org.settings, "recommend-category"),
 		release: isAiFeatureEnabled(access.org.settings, "recommend-release"),
 		relations: isAiFeatureEnabled(access.org.settings, "recommend-relations"),
+		status: isAiFeatureEnabled(access.org.settings, "recommend-status"),
 	};
 
 	if (!Object.values(enabled).some(Boolean)) {
@@ -199,6 +290,9 @@ recommendationsRoute.post("/", async (c) => {
 	}
 
 	const descriptionText = task.description ? extractPlainText(task.description) : "No description provided.";
+
+	// ---- Status: rule-based, computed independently of the LLM call below ----
+	const statusSuggestion = enabled.status ? await computeStatusSuggestion(orgId, taskId, task) : null;
 
 	// ---- Nearest-neighbor tasks: relation candidates + label/category evidence ----
 	// Computed once, up front — both the relations kind and the evidence lines
@@ -344,9 +438,11 @@ recommendationsRoute.post("/", async (c) => {
 	}
 
 	if (hintParts.length === 0) {
-		// Every enabled kind had nothing to offer (no labels/other members/releases/etc. in this org) —
-		// nothing to ask the model, skip the call entirely.
-		return c.json({ success: true, data: emptyResult() });
+		// Every LLM-backed kind had nothing to offer (no labels/other
+		// members/releases/etc. in this org) — nothing to ask the model, skip
+		// the call entirely. Status is computed separately above and still
+		// applies here since it never depended on the LLM.
+		return c.json({ success: true, data: { ...emptyResult(), status: statusSuggestion } });
 	}
 
 	shape.reasoning = z.string().optional();
@@ -420,6 +516,7 @@ recommendationsRoute.post("/", async (c) => {
 		categoryId,
 		releaseId,
 		relations,
+		status: statusSuggestion,
 		reasoning: data.reasoning as string | undefined,
 		systemPrompt: recommendationsPrompt.systemPrompt,
 		userPrompt,

--- a/apps/start/src/components/pages/admin/settings/orgId/ai.tsx
+++ b/apps/start/src/components/pages/admin/settings/orgId/ai.tsx
@@ -76,6 +76,12 @@ const RECOMMENDATION_KINDS: { id: string; label: string; description: string }[]
 		label: "Relations",
 		description: "Flag likely duplicate, blocking, or related tasks from this organization's recent tasks.",
 	},
+	{
+		id: "recommend-status",
+		label: "Status",
+		description:
+			"Suggest moving a task to In Progress or Done based on linked GitHub activity — a linked branch, commit, mention, or merged PR.",
+	},
 ];
 
 export default function AiSettingsPage({ locked }: { locked?: boolean }) {

--- a/apps/start/src/components/tasks/shared/config.tsx
+++ b/apps/start/src/components/tasks/shared/config.tsx
@@ -1,474 +1,560 @@
 import type { schema } from "@repo/database";
-import { Avatar, AvatarFallback, AvatarImage } from "@repo/ui/components/avatar";
+import {
+  Avatar,
+  AvatarFallback,
+  AvatarImage,
+} from "@repo/ui/components/avatar";
 import PriorityIcon from "@repo/ui/components/icons/priority";
 import StatusIcon from "@repo/ui/components/icons/status";
 import { getInitials } from "@repo/util";
-import { IconAlertSquareFilled, IconCategory2, IconRocket, IconUser } from "@tabler/icons-react";
-import type { TaskGroup, TaskGroupingContext, TaskGroupingDefinition, TaskGroupingId } from "../filter/types";
+import {
+  IconAlertSquareFilled,
+  IconCategory2,
+  IconRocket,
+  IconUser,
+} from "@tabler/icons-react";
+import type {
+  TaskGroup,
+  TaskGroupingContext,
+  TaskGroupingDefinition,
+  TaskGroupingId,
+} from "../filter/types";
 
 export const statusConfig = {
-	backlog: {
-		label: "Backlog",
-		icon: (className: string) => <StatusIcon status="backlog" className={className} />,
-		className: "text-muted-foreground",
-		color: "#6B7280",
-		hsla: "hsla(220, 8.94%, 46.08%, 1)",
-		var: "muted-foreground",
-	},
-	todo: {
-		label: "Todo",
-		icon: (className: string) => <StatusIcon status="todo" className={className} />,
-		className: "text-foreground",
-		color: "#3B82F6",
-		hsla: "hsla(217.22, 91.22%, 59.8%, 1)",
-		var: "foreground",
-	},
-	"in-progress": {
-		label: "In Progress",
-		icon: (className: string) => <StatusIcon status="in-progress" className={className} />,
-		className: "text-primary fill-primary",
-		color: "#F59E0B",
-		hsla: "hsla(37.69, 92.13%, 50.2%, 1)",
-		var: "primary",
-	},
-	done: {
-		label: "Done",
-		icon: (className: string) => <StatusIcon status="done" className={className} />,
-		className: "text-success",
-		color: "#10B981",
-		hsla: "hsla(141.43, 99.9%, 59.8%, 1)",
-		var: "success",
-	},
-	canceled: {
-		label: "Canceled",
-		icon: (className: string) => <StatusIcon status="canceled" className={className} />,
-		className: "text-desctructive",
-		color: "#EF4444",
-		hsla: "hsla(359.43, 99.9%, 59.8%, 1)",
-		var: "destructive",
-	},
+  backlog: {
+    label: "Backlog",
+    icon: (className: string) => (
+      <StatusIcon status="backlog" className={className} />
+    ),
+    className: "text-muted-foreground",
+    color: "#6B7280",
+    hsla: "hsla(220, 8.94%, 46.08%, 1)",
+    var: "muted-foreground",
+  },
+  todo: {
+    label: "Todo",
+    icon: (className: string) => (
+      <StatusIcon status="todo" className={className} />
+    ),
+    className: "text-foreground",
+    color: "#3B82F6",
+    hsla: "hsla(217.22, 91.22%, 59.8%, 1)",
+    var: "foreground",
+  },
+  "in-progress": {
+    label: "In Progress",
+    icon: (className: string) => (
+      <StatusIcon status="in-progress" className={className} />
+    ),
+    className: "text-primary fill-primary",
+    color: "#F59E0B",
+    hsla: "hsla(37.69, 92.13%, 50.2%, 1)",
+    var: "primary",
+  },
+  done: {
+    label: "Done",
+    icon: (className: string) => (
+      <StatusIcon status="done" className={className} />
+    ),
+    className: "text-success",
+    color: "#10B981",
+    hsla: "hsla(141.43, 99.9%, 59.8%, 1)",
+    var: "success",
+  },
+  canceled: {
+    label: "Canceled",
+    icon: (className: string) => (
+      <StatusIcon status="canceled" className={className} />
+    ),
+    className: "text-desctructive",
+    color: "#EF4444",
+    hsla: "hsla(359.43, 99.9%, 59.8%, 1)",
+    var: "destructive",
+  },
 } as const;
 
 export const priorityConfig = {
-	low: {
-		label: "Low",
-		icon: (className: string) => <PriorityIcon bars={1} className={className} />,
-		className: "text-gray-500",
-		color: "#6B7280",
-	},
-	medium: {
-		label: "Medium",
-		icon: (className: string) => <PriorityIcon bars={2} className={className} />,
-		className: "text-yellow-500",
-		color: "#F59E0B",
-	},
-	high: {
-		label: "High",
-		icon: (className: string) => <PriorityIcon bars={3} className={className} />,
-		className: "text-red-500",
-		color: "#EF4444",
-	},
-	urgent: {
-		label: "Urgent",
-		icon: (className: string) => <IconAlertSquareFilled className={className} />,
-		className: "text-destructive",
-		color: "#DC2626",
-	},
-	none: {
-		label: "No Priority",
-		icon: (className: string) => <PriorityIcon bars="none" className={className} />,
-		className: "text-muted-foreground",
-		color: "#9CA3AF",
-	},
+  low: {
+    label: "Low",
+    icon: (className: string) => (
+      <PriorityIcon bars={1} className={className} />
+    ),
+    className: "text-gray-500",
+    color: "#6B7280",
+  },
+  medium: {
+    label: "Medium",
+    icon: (className: string) => (
+      <PriorityIcon bars={2} className={className} />
+    ),
+    className: "text-yellow-500",
+    color: "#F59E0B",
+  },
+  high: {
+    label: "High",
+    icon: (className: string) => (
+      <PriorityIcon bars={3} className={className} />
+    ),
+    className: "text-red-500",
+    color: "#EF4444",
+  },
+  urgent: {
+    label: "Urgent",
+    icon: (className: string) => (
+      <IconAlertSquareFilled className={className} />
+    ),
+    className: "text-destructive",
+    color: "#DC2626",
+  },
+  none: {
+    label: "No Priority",
+    icon: (className: string) => (
+      <PriorityIcon bars="none" className={className} />
+    ),
+    className: "text-muted-foreground",
+    color: "#9CA3AF",
+  },
 } as const;
 
 export type StatusKey = keyof typeof statusConfig;
 export type PriorityKey = keyof typeof priorityConfig;
 
 export interface GroupHeaderStyle {
-	rootClassName?: string;
-	getItemClassName?: (key: string) => string | undefined;
+  rootClassName?: string;
+  getItemClassName?: (key: string) => string | undefined;
 }
 
 export const GROUP_HEADER_STYLES: Record<TaskGroupingId, GroupHeaderStyle> = {
-	status: {
-		rootClassName: "bg-background",
-		getItemClassName: (key: string) => {
-			switch (key as StatusKey) {
-				case "backlog":
-					return "bg-muted";
-				case "todo":
-					return "bg-muted";
-				case "in-progress":
-					return "bg-primary/5";
-				case "done":
-					return "bg-success/5";
-				case "canceled":
-					return "bg-destructive/5";
-				default:
-					return undefined;
-			}
-		},
-	},
-	priority: {
-		rootClassName: undefined,
-		getItemClassName: (key: string) => {
-			switch (key as PriorityKey) {
-				case "urgent":
-					return "bg-destructive/5";
-				case "high":
-					return "bg-orange-800/5";
-				case "medium":
-					return "bg-primary/5";
-				case "low":
-					return "bg-muted";
-				case "none":
-					return undefined;
-				default:
-					return undefined;
-			}
-		},
-	},
-	assignee: {
-		rootClassName: undefined,
-		getItemClassName: () => undefined,
-	},
-	category: {
-		rootClassName: undefined,
-		getItemClassName: () => undefined,
-	},
-	release: {
-		rootClassName: undefined,
-		getItemClassName: () => undefined,
-	},
+  status: {
+    rootClassName: "bg-background",
+    getItemClassName: (key: string) => {
+      switch (key as StatusKey) {
+        case "backlog":
+          return "bg-muted";
+        case "todo":
+          return "bg-muted";
+        case "in-progress":
+          return "bg-primary/5";
+        case "done":
+          return "bg-success/5";
+        case "canceled":
+          return "bg-destructive/5";
+        default:
+          return undefined;
+      }
+    },
+  },
+  priority: {
+    rootClassName: undefined,
+    getItemClassName: (key: string) => {
+      switch (key as PriorityKey) {
+        case "urgent":
+          return "bg-destructive/10";
+        case "high":
+          return "bg-orange-800/15";
+        case "medium":
+          return "bg-primary/5";
+        case "low":
+          return "bg-card/5";
+        case "none":
+          return undefined;
+        default:
+          return undefined;
+      }
+    },
+  },
+  assignee: {
+    rootClassName: undefined,
+    getItemClassName: () => undefined,
+  },
+  category: {
+    rootClassName: undefined,
+    getItemClassName: () => undefined,
+  },
+  release: {
+    rootClassName: undefined,
+    getItemClassName: () => undefined,
+  },
 };
 
-const STATUS_ORDER: Array<keyof typeof statusConfig> = ["backlog", "todo", "in-progress", "done", "canceled"];
-const PRIORITY_ORDER: Array<keyof typeof priorityConfig> = ["urgent", "high", "medium", "low", "none"];
-const COMPLETED_STATUSES: Array<keyof typeof statusConfig> = ["done", "canceled"];
-const filterCompletedTasks = (tasks: schema.TaskWithLabels[], showCompletedTasks: boolean): schema.TaskWithLabels[] => {
-	if (showCompletedTasks) return tasks;
-	return tasks.filter((task) => !COMPLETED_STATUSES.includes(task.status as keyof typeof statusConfig));
+const STATUS_ORDER: Array<keyof typeof statusConfig> = [
+  "backlog",
+  "todo",
+  "in-progress",
+  "done",
+  "canceled",
+];
+const PRIORITY_ORDER: Array<keyof typeof priorityConfig> = [
+  "urgent",
+  "high",
+  "medium",
+  "low",
+  "none",
+];
+const COMPLETED_STATUSES: Array<keyof typeof statusConfig> = [
+  "done",
+  "canceled",
+];
+const filterCompletedTasks = (
+  tasks: schema.TaskWithLabels[],
+  showCompletedTasks: boolean,
+): schema.TaskWithLabels[] => {
+  if (showCompletedTasks) return tasks;
+  return tasks.filter(
+    (task) =>
+      !COMPLETED_STATUSES.includes(task.status as keyof typeof statusConfig),
+  );
 };
 
 const createInitialStatusGroups = () =>
-	STATUS_ORDER.map((statusKey) => {
-		const config = statusConfig[statusKey];
-		return {
-			id: `status:${statusKey}`,
-			key: statusKey,
-			label: config.label,
-			count: 0,
-			tasks: [] as schema.TaskWithLabels[],
-			icon: config.icon("h-4 w-4"),
-			description: undefined,
-			accentClassName: config.className,
-		};
-	});
+  STATUS_ORDER.map((statusKey) => {
+    const config = statusConfig[statusKey];
+    return {
+      id: `status:${statusKey}`,
+      key: statusKey,
+      label: config.label,
+      count: 0,
+      tasks: [] as schema.TaskWithLabels[],
+      icon: config.icon("h-4 w-4"),
+      description: undefined,
+      accentClassName: config.className,
+    };
+  });
 
 const createInitialPriorityGroups = () =>
-	PRIORITY_ORDER.map((priorityKey) => {
-		const config = priorityConfig[priorityKey];
-		return {
-			id: `priority:${priorityKey}`,
-			key: priorityKey,
-			label: config.label,
-			count: 0,
-			tasks: [] as schema.TaskWithLabels[],
-			icon: config.icon("h-4 w-4"),
-			description: undefined,
-			accentClassName: config.className,
-		};
-	});
+  PRIORITY_ORDER.map((priorityKey) => {
+    const config = priorityConfig[priorityKey];
+    return {
+      id: `priority:${priorityKey}`,
+      key: priorityKey,
+      label: config.label,
+      count: 0,
+      tasks: [] as schema.TaskWithLabels[],
+      icon: config.icon("h-4 w-4"),
+      description: undefined,
+      accentClassName: config.className,
+    };
+  });
 
 type AssigneeDisplay = {
-	id: string;
-	name?: string | null;
-	email?: string | null;
-	image?: string | null;
+  id: string;
+  name?: string | null;
+  email?: string | null;
+  image?: string | null;
 };
 
 const createAssigneeGroup = (user: AssigneeDisplay | undefined) => {
-	const id = user ? `assignee:${user.id}` : "assignee:unassigned";
-	const label = user?.name || user?.email || "Unassigned";
-	return {
-		id,
-		key: user?.id || "unassigned",
-		label,
-		count: 0,
-		tasks: [] as schema.TaskWithLabels[],
-		icon: user ? (
-			<Avatar className="h-4 w-4 border border-border">
-				<AvatarImage src={user.image || undefined} />
-				<AvatarFallback className="text-xs">{getInitials(user?.name || user?.email)}</AvatarFallback>
-			</Avatar>
-		) : (
-			<div className="flex h-4 w-4 items-center justify-center rounded-full border border-dashed border-border text-muted-foreground">
-				<IconUser className="h-4 w-4" />
-			</div>
-		),
-		description: undefined,
-		accentClassName: undefined,
-		metadata: user ? { user } : undefined,
-	};
+  const id = user ? `assignee:${user.id}` : "assignee:unassigned";
+  const label = user?.name || user?.email || "Unassigned";
+  return {
+    id,
+    key: user?.id || "unassigned",
+    label,
+    count: 0,
+    tasks: [] as schema.TaskWithLabels[],
+    icon: user ? (
+      <Avatar className="h-4 w-4 border border-border">
+        <AvatarImage src={user.image || undefined} />
+        <AvatarFallback className="text-xs">
+          {getInitials(user?.name || user?.email)}
+        </AvatarFallback>
+      </Avatar>
+    ) : (
+      <div className="flex h-4 w-4 items-center justify-center rounded-full border border-dashed border-border text-muted-foreground">
+        <IconUser className="h-4 w-4" />
+      </div>
+    ),
+    description: undefined,
+    accentClassName: undefined,
+    metadata: user ? { user } : undefined,
+  };
 };
 
 const statusGrouping = createGroupingDefinition("status", {
-	label: "Status",
-	description: "Group tasks by their workflow status",
-	icon: statusConfig.todo.icon("h-4 w-4"),
-	group: ({ tasks, showCompletedTasks }: TaskGroupingContext) => {
-		const filteredTasks = filterCompletedTasks(tasks, showCompletedTasks);
-		const groups = createInitialStatusGroups();
-		const fallbackGroup = groups[0];
-		if (!fallbackGroup) {
-			return [];
-		}
+  label: "Status",
+  description: "Group tasks by their workflow status",
+  icon: statusConfig.todo.icon("h-4 w-4"),
+  group: ({ tasks, showCompletedTasks }: TaskGroupingContext) => {
+    const filteredTasks = filterCompletedTasks(tasks, showCompletedTasks);
+    const groups = createInitialStatusGroups();
+    const fallbackGroup = groups[0];
+    if (!fallbackGroup) {
+      return [];
+    }
 
-		filteredTasks.forEach((task) => {
-			const statusKey = (task.status as keyof typeof statusConfig) || fallbackGroup.key;
-			const target = groups.find((g) => g.key === statusKey) ?? fallbackGroup;
-			target.tasks.push(task);
-		});
+    filteredTasks.forEach((task) => {
+      const statusKey =
+        (task.status as keyof typeof statusConfig) || fallbackGroup.key;
+      const target = groups.find((g) => g.key === statusKey) ?? fallbackGroup;
+      target.tasks.push(task);
+    });
 
-		return groups
-			.map((group) => ({ ...group, count: group.tasks.length }))
-			.filter((group) => {
-				// Hide completed status groups when showCompletedTasks is false
-				if (!showCompletedTasks && COMPLETED_STATUSES.includes(group.key as keyof typeof statusConfig)) {
-					return false;
-				}
-				return true; // Always show all groups
-			});
-	},
+    return groups
+      .map((group) => ({ ...group, count: group.tasks.length }))
+      .filter((group) => {
+        // Hide completed status groups when showCompletedTasks is false
+        if (
+          !showCompletedTasks &&
+          COMPLETED_STATUSES.includes(group.key as keyof typeof statusConfig)
+        ) {
+          return false;
+        }
+        return true; // Always show all groups
+      });
+  },
 });
 
 const priorityGrouping = createGroupingDefinition("priority", {
-	label: "Priority",
-	description: "Group tasks by priority level",
-	icon: priorityConfig.medium.icon("h-4 w-4"),
-	group: ({ tasks, showCompletedTasks }: TaskGroupingContext) => {
-		const filteredTasks = filterCompletedTasks(tasks, showCompletedTasks);
-		const groups = createInitialPriorityGroups();
-		const fallbackGroup = groups.find((group) => group.key === "none") ?? groups[0];
-		if (!fallbackGroup) {
-			return [];
-		}
+  label: "Priority",
+  description: "Group tasks by priority level",
+  icon: priorityConfig.medium.icon("h-4 w-4"),
+  group: ({ tasks, showCompletedTasks }: TaskGroupingContext) => {
+    const filteredTasks = filterCompletedTasks(tasks, showCompletedTasks);
+    const groups = createInitialPriorityGroups();
+    const fallbackGroup =
+      groups.find((group) => group.key === "none") ?? groups[0];
+    if (!fallbackGroup) {
+      return [];
+    }
 
-		filteredTasks.forEach((task) => {
-			const priorityKey = (task.priority as keyof typeof priorityConfig) || fallbackGroup.key;
-			const target = groups.find((g) => g.key === priorityKey) ?? fallbackGroup;
-			target.tasks.push(task);
-		});
+    filteredTasks.forEach((task) => {
+      const priorityKey =
+        (task.priority as keyof typeof priorityConfig) || fallbackGroup.key;
+      const target = groups.find((g) => g.key === priorityKey) ?? fallbackGroup;
+      target.tasks.push(task);
+    });
 
-		return groups.map((group) => ({ ...group, count: group.tasks.length }));
-	},
+    return groups.map((group) => ({ ...group, count: group.tasks.length }));
+  },
 });
 
 const assigneeGrouping = createGroupingDefinition("assignee", {
-	label: "Assignee",
-	description: "Group tasks by assigned team members",
-	icon: <IconUser className="h-4 w-4" />,
-	group: ({ tasks, availableUsers, showCompletedTasks }: TaskGroupingContext) => {
-		const filteredTasks = filterCompletedTasks(tasks, showCompletedTasks);
-		const groupMap = new Map<string, TaskGroup>();
+  label: "Assignee",
+  description: "Group tasks by assigned team members",
+  icon: <IconUser className="h-4 w-4" />,
+  group: ({
+    tasks,
+    availableUsers,
+    showCompletedTasks,
+  }: TaskGroupingContext) => {
+    const filteredTasks = filterCompletedTasks(tasks, showCompletedTasks);
+    const groupMap = new Map<string, TaskGroup>();
 
-		const ensureGroupForUser = (user: AssigneeDisplay | undefined) => {
-			const key = user?.id || "unassigned";
-			const existing = groupMap.get(key);
-			if (existing) {
-				return existing;
-			}
-			const created = createAssigneeGroup(user);
-			groupMap.set(key, created);
-			return created;
-		};
+    const ensureGroupForUser = (user: AssigneeDisplay | undefined) => {
+      const key = user?.id || "unassigned";
+      const existing = groupMap.get(key);
+      if (existing) {
+        return existing;
+      }
+      const created = createAssigneeGroup(user);
+      groupMap.set(key, created);
+      return created;
+    };
 
-		// Always create groups for all available users
-		availableUsers.forEach((user) => {
-			ensureGroupForUser(user);
-		});
-		ensureGroupForUser(undefined);
+    // Always create groups for all available users
+    availableUsers.forEach((user) => {
+      ensureGroupForUser(user);
+    });
+    ensureGroupForUser(undefined);
 
-		filteredTasks.forEach((task) => {
-			if (task.assignees && task.assignees.length > 0) {
-				task.assignees.forEach((assignee) => {
-					const matchingUser = availableUsers.find((user) => user.id === assignee.id);
-					const fallbackUser: AssigneeDisplay = {
-						id: assignee.id,
-						name: assignee.name,
-						image: assignee.image,
-					};
-					const group = ensureGroupForUser(matchingUser ?? fallbackUser);
-					group.tasks.push(task);
-				});
-			} else {
-				const unassignedGroup = ensureGroupForUser(undefined);
-				unassignedGroup.tasks.push(task);
-			}
-		});
+    filteredTasks.forEach((task) => {
+      if (task.assignees && task.assignees.length > 0) {
+        task.assignees.forEach((assignee) => {
+          const matchingUser = availableUsers.find(
+            (user) => user.id === assignee.id,
+          );
+          const fallbackUser: AssigneeDisplay = {
+            id: assignee.id,
+            name: assignee.name,
+            image: assignee.image,
+          };
+          const group = ensureGroupForUser(matchingUser ?? fallbackUser);
+          group.tasks.push(task);
+        });
+      } else {
+        const unassignedGroup = ensureGroupForUser(undefined);
+        unassignedGroup.tasks.push(task);
+      }
+    });
 
-		const groups = Array.from(groupMap.values()).map((group) => ({
-			...group,
-			count: group.tasks.length,
-		}));
+    const groups = Array.from(groupMap.values()).map((group) => ({
+      ...group,
+      count: group.tasks.length,
+    }));
 
-		return groups.sort((a, b) => {
-			if (a.key === "unassigned") return 1;
-			if (b.key === "unassigned") return -1;
-			return a.label.localeCompare(b.label);
-		});
-	},
+    return groups.sort((a, b) => {
+      if (a.key === "unassigned") return 1;
+      if (b.key === "unassigned") return -1;
+      return a.label.localeCompare(b.label);
+    });
+  },
 });
-const createCategoryGroup = (category?: schema.categoryType | null): TaskGroup => {
-	const key = category?.id || "uncategorized";
-	const id = category?.id ? `category:${category.id}` : "category:none";
-	return {
-		id,
-		key,
-		label: category?.name || "No category",
-		icon: <div className="h-3 w-3 rounded-full border" style={{ backgroundColor: category?.color || "#cccccc" }} />,
-		tasks: [],
-		count: 0,
-	};
+const createCategoryGroup = (
+  category?: schema.categoryType | null,
+): TaskGroup => {
+  const key = category?.id || "uncategorized";
+  const id = category?.id ? `category:${category.id}` : "category:none";
+  return {
+    id,
+    key,
+    label: category?.name || "No category",
+    icon: (
+      <div
+        className="h-3 w-3 rounded-full border"
+        style={{ backgroundColor: category?.color || "#cccccc" }}
+      />
+    ),
+    tasks: [],
+    count: 0,
+  };
 };
 export const categoryGrouping = createGroupingDefinition("category", {
-	label: "Category",
-	description: "Group tasks by categories",
-	icon: <IconCategory2 className="h-4 w-4" />,
-	group: ({ tasks, showCompletedTasks, categories }: TaskGroupingContext) => {
-		const filteredTasks = filterCompletedTasks(tasks, showCompletedTasks);
-		const groupMap = new Map<string, TaskGroup>();
+  label: "Category",
+  description: "Group tasks by categories",
+  icon: <IconCategory2 className="h-4 w-4" />,
+  group: ({ tasks, showCompletedTasks, categories }: TaskGroupingContext) => {
+    const filteredTasks = filterCompletedTasks(tasks, showCompletedTasks);
+    const groupMap = new Map<string, TaskGroup>();
 
-		// Safely create or retrieve a group without using non-null assertions
-		const ensureGroupForCategory = (category?: schema.categoryType | null): TaskGroup => {
-			const key = category?.id || "uncategorized";
-			const existingGroup = groupMap.get(key);
-			if (existingGroup) {
-				return existingGroup;
-			}
-			const newGroup = createCategoryGroup(category);
-			groupMap.set(key, newGroup);
-			return newGroup;
-		};
+    // Safely create or retrieve a group without using non-null assertions
+    const ensureGroupForCategory = (
+      category?: schema.categoryType | null,
+    ): TaskGroup => {
+      const key = category?.id || "uncategorized";
+      const existingGroup = groupMap.get(key);
+      if (existingGroup) {
+        return existingGroup;
+      }
+      const newGroup = createCategoryGroup(category);
+      groupMap.set(key, newGroup);
+      return newGroup;
+    };
 
-		// Always pre-create groups for all categories
-		categories.forEach((cat) => ensureGroupForCategory(cat));
-		ensureGroupForCategory(null); // Uncategorized
+    // Always pre-create groups for all categories
+    categories.forEach((cat) => ensureGroupForCategory(cat));
+    ensureGroupForCategory(null); // Uncategorized
 
-		// Assign each task to a category-based group
-		filteredTasks.forEach((task) => {
-			// Handle both string-based and object-based category fields
-			let category: schema.categoryType | null = null;
-			if (typeof task.category === "string") {
-				category = categories.find((c) => c.id === task.category) ?? null;
-			} else if (task.category && typeof task.category === "object") {
-				category = task.category as schema.categoryType;
-			}
+    // Assign each task to a category-based group
+    filteredTasks.forEach((task) => {
+      // Handle both string-based and object-based category fields
+      let category: schema.categoryType | null = null;
+      if (typeof task.category === "string") {
+        category = categories.find((c) => c.id === task.category) ?? null;
+      } else if (task.category && typeof task.category === "object") {
+        category = task.category as schema.categoryType;
+      }
 
-			const group = ensureGroupForCategory(category);
-			group.tasks.push(task);
-		});
+      const group = ensureGroupForCategory(category);
+      group.tasks.push(task);
+    });
 
-		// Compute counts for all groups
-		const groups = Array.from(groupMap.values()).map((group) => ({
-			...group,
-			count: group.tasks.length,
-		}));
+    // Compute counts for all groups
+    const groups = Array.from(groupMap.values()).map((group) => ({
+      ...group,
+      count: group.tasks.length,
+    }));
 
-		// Sort alphabetically, with "No category" last
-		return groups.sort((a, b) => {
-			if (a.key === "uncategorized") return 1;
-			if (b.key === "uncategorized") return -1;
-			return a.label.localeCompare(b.label);
-		});
-	},
+    // Sort alphabetically, with "No category" last
+    return groups.sort((a, b) => {
+      if (a.key === "uncategorized") return 1;
+      if (b.key === "uncategorized") return -1;
+      return a.label.localeCompare(b.label);
+    });
+  },
 });
 
 const createReleaseGroup = (release?: schema.releaseType | null): TaskGroup => {
-	const key = release?.id || "no-release";
-	const id = release?.id ? `release:${release.id}` : "release:none";
-	return {
-		id,
-		key,
-		label: release?.name || "No release",
-		icon: release?.icon ? (
-			<span className="text-lg">{release.icon}</span>
-		) : (
-			<div className="h-3 w-3 rounded-full border" style={{ backgroundColor: release?.color || "#cccccc" }} />
-		),
-		tasks: [],
-		count: 0,
-	};
+  const key = release?.id || "no-release";
+  const id = release?.id ? `release:${release.id}` : "release:none";
+  return {
+    id,
+    key,
+    label: release?.name || "No release",
+    icon: release?.icon ? (
+      <span className="text-lg">{release.icon}</span>
+    ) : (
+      <div
+        className="h-3 w-3 rounded-full border"
+        style={{ backgroundColor: release?.color || "#cccccc" }}
+      />
+    ),
+    tasks: [],
+    count: 0,
+  };
 };
 
 export const releaseGrouping = createGroupingDefinition("release", {
-	label: "Release",
-	description: "Group tasks by releases",
-	icon: <IconRocket className="h-4 w-4" />,
-	group: ({ tasks, showCompletedTasks, releases }: TaskGroupingContext) => {
-		const filteredTasks = filterCompletedTasks(tasks, showCompletedTasks);
-		const groupMap = new Map<string, TaskGroup>();
+  label: "Release",
+  description: "Group tasks by releases",
+  icon: <IconRocket className="h-4 w-4" />,
+  group: ({ tasks, showCompletedTasks, releases }: TaskGroupingContext) => {
+    const filteredTasks = filterCompletedTasks(tasks, showCompletedTasks);
+    const groupMap = new Map<string, TaskGroup>();
 
-		// Safely create or retrieve a group without using non-null assertions
-		const ensureGroupForRelease = (release?: schema.releaseType | null): TaskGroup => {
-			const key = release?.id || "no-release";
-			const existingGroup = groupMap.get(key);
-			if (existingGroup) {
-				return existingGroup;
-			}
-			const newGroup = createReleaseGroup(release);
-			groupMap.set(key, newGroup);
-			return newGroup;
-		};
+    // Safely create or retrieve a group without using non-null assertions
+    const ensureGroupForRelease = (
+      release?: schema.releaseType | null,
+    ): TaskGroup => {
+      const key = release?.id || "no-release";
+      const existingGroup = groupMap.get(key);
+      if (existingGroup) {
+        return existingGroup;
+      }
+      const newGroup = createReleaseGroup(release);
+      groupMap.set(key, newGroup);
+      return newGroup;
+    };
 
-		// Always pre-create groups for all releases
-		releases.forEach((rel) => ensureGroupForRelease(rel));
-		ensureGroupForRelease(null); // No release
+    // Always pre-create groups for all releases
+    releases.forEach((rel) => ensureGroupForRelease(rel));
+    ensureGroupForRelease(null); // No release
 
-		// Assign each task to a release-based group
-		filteredTasks.forEach((task) => {
-			// Find the release by ID
-			const release = task.releaseId ? (releases.find((r) => r.id === task.releaseId) ?? null) : null;
+    // Assign each task to a release-based group
+    filteredTasks.forEach((task) => {
+      // Find the release by ID
+      const release = task.releaseId
+        ? (releases.find((r) => r.id === task.releaseId) ?? null)
+        : null;
 
-			const group = ensureGroupForRelease(release);
-			group.tasks.push(task);
-		});
+      const group = ensureGroupForRelease(release);
+      group.tasks.push(task);
+    });
 
-		// Compute counts for all groups
-		const groups = Array.from(groupMap.values()).map((group) => ({
-			...group,
-			count: group.tasks.length,
-		}));
+    // Compute counts for all groups
+    const groups = Array.from(groupMap.values()).map((group) => ({
+      ...group,
+      count: group.tasks.length,
+    }));
 
-		// Sort by slug (for semver), with "No release" last
-		return groups.sort((a, b) => {
-			if (a.key === "no-release") return 1;
-			if (b.key === "no-release") return -1;
-			return a.label.localeCompare(b.label);
-		});
-	},
+    // Sort by slug (for semver), with "No release" last
+    return groups.sort((a, b) => {
+      if (a.key === "no-release") return 1;
+      if (b.key === "no-release") return -1;
+      return a.label.localeCompare(b.label);
+    });
+  },
 });
 
 function createGroupingDefinition(
-	id: TaskGroupingId,
-	definition: Omit<TaskGroupingDefinition, "id">
+  id: TaskGroupingId,
+  definition: Omit<TaskGroupingDefinition, "id">,
 ): TaskGroupingDefinition {
-	return {
-		id,
-		...definition,
-	};
+  return {
+    id,
+    ...definition,
+  };
 }
 
 export const TASK_GROUPINGS: Record<TaskGroupingId, TaskGroupingDefinition> = {
-	status: statusGrouping,
-	priority: priorityGrouping,
-	assignee: assigneeGrouping,
-	category: categoryGrouping,
-	release: releaseGrouping,
+  status: statusGrouping,
+  priority: priorityGrouping,
+  assignee: assigneeGrouping,
+  category: categoryGrouping,
+  release: releaseGrouping,
 };
 
-export const TASK_GROUPING_OPTIONS: TaskGroupingDefinition[] = Object.values(TASK_GROUPINGS);
+export const TASK_GROUPING_OPTIONS: TaskGroupingDefinition[] =
+  Object.values(TASK_GROUPINGS);
 
 export const DEFAULT_STATUS_ORDER = STATUS_ORDER;
 export const DEFAULT_PRIORITY_ORDER = PRIORITY_ORDER;

--- a/apps/start/src/components/tasks/task/task-ai-recommendations.tsx
+++ b/apps/start/src/components/tasks/task/task-ai-recommendations.tsx
@@ -3,6 +3,7 @@ import { Badge } from "@repo/ui/components/badge";
 import { Button } from "@repo/ui/components/button";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@repo/ui/components/collapsible";
 import { headlessToast } from "@repo/ui/components/headless-toast";
+import StatusIcon from "@repo/ui/components/icons/status";
 import { Spinner } from "@repo/ui/components/spinner";
 import { useStateManagement } from "@repo/ui/hooks/useStateManagement.ts";
 import { formatTaskKey, resolveOrgAiStatus } from "@repo/util";
@@ -28,8 +29,15 @@ import { getCategoryUpdatePayload } from "@/components/tasks/actions/category";
 import { getLabelBulkUpdatePayload } from "@/components/tasks/actions/labels";
 import { getPriorityUpdatePayload } from "@/components/tasks/actions/priority";
 import { getReleaseUpdatePayload } from "@/components/tasks/actions/release";
+import { getStatusUpdatePayload } from "@/components/tasks/actions/status";
 import { useTaskFieldAction } from "@/components/tasks/actions/use-task-field-action";
-import { getTaskRecommendations, type RecommendationsResult, type RecommendedRelation } from "@/lib/fetches/ai";
+import { statusConfig as sharedStatusConfig } from "@/components/tasks/shared/config";
+import {
+	getTaskRecommendations,
+	type RecommendationsResult,
+	type RecommendedRelation,
+	type RecommendedStatus,
+} from "@/lib/fetches/ai";
 import { createTaskRelationAction } from "@/lib/fetches/task";
 import { ContextSection } from "./task-context-banner";
 
@@ -63,15 +71,18 @@ interface SuggestionChipProps {
 	 */
 	meta?: string;
 	label: string;
+	/** Optional hover tooltip — e.g. the concrete signal behind a status suggestion ("Jane linked branch feature/foo"). */
+	title?: string;
 	onApply: () => void;
 	onDismiss: () => void;
 }
 
 /** One reusable clickable chip shared by every recommendation kind — click the body to apply, the "x" to dismiss without applying. */
-function SuggestionChip({ icon, meta, label, onApply, onDismiss }: SuggestionChipProps) {
+function SuggestionChip({ icon, meta, label, title, onApply, onDismiss }: SuggestionChipProps) {
 	return (
 		<Badge
 			variant="secondary"
+			title={title}
 			className="flex items-center gap-1.5 bg-accent text-xs h-auto border border-dashed border-border rounded-2xl pl-2 pr-1 py-1 max-w-64"
 		>
 			<button type="button" onClick={onApply} className="flex items-center gap-1.5 min-w-0 cursor-pointer">
@@ -184,7 +195,8 @@ export function useAiRecommendations({
 				res.data.priority ||
 				res.data.categoryId ||
 				res.data.releaseId ||
-				res.data.relations.length > 0;
+				res.data.relations.length > 0 ||
+				res.data.status;
 
 			if (forceRefresh && !hasAny) {
 				headlessToast.info({
@@ -302,6 +314,13 @@ export function useAiRecommendations({
 				}
 		);
 
+	const applyStatus = () => {
+		if (!result?.status) return;
+		execute(getStatusUpdatePayload(task, result.status.value));
+		setResult((prev) => prev && { ...prev, status: null });
+	};
+	const dismissStatus = () => setResult((prev) => prev && { ...prev, status: null });
+
 	return {
 		recommendationsAvailable,
 		orgShortId: org?.shortId ?? "",
@@ -321,6 +340,8 @@ export function useAiRecommendations({
 		dismissRelease,
 		applyRelation,
 		dismissRelation,
+		applyStatus,
+		dismissStatus,
 	};
 }
 
@@ -363,6 +384,7 @@ function AiRecommendationsContent({
 	const suggestedCategory = r.result?.categoryId ? categories.find((c) => c.id === r.result?.categoryId) : null;
 	const suggestedRelease = r.result?.releaseId ? releases.find((rel) => rel.id === r.result?.releaseId) : null;
 	const suggestedRelations = r.result?.relations ?? [];
+	const suggestedStatus: RecommendedStatus | null = r.result?.status ?? null;
 
 	const hasContent =
 		suggestedLabels.length > 0 ||
@@ -370,7 +392,8 @@ function AiRecommendationsContent({
 		Boolean(r.result?.priority) ||
 		Boolean(suggestedCategory) ||
 		Boolean(suggestedRelease) ||
-		suggestedRelations.length > 0;
+		suggestedRelations.length > 0 ||
+		Boolean(suggestedStatus);
 
 	const regenerateButton = isPlatformAdmin && (
 		<Button
@@ -487,6 +510,26 @@ function AiRecommendationsContent({
 						</div>
 					)}
 
+					{suggestedStatus && (
+						<div className="flex flex-col gap-1.5">
+							<div className="flex flex-wrap items-center gap-2">
+								<span className="text-xs text-foreground font-semibold">Status:</span>
+								<SuggestionChip
+									icon={
+										<StatusIcon
+											status={suggestedStatus.value}
+											className={`size-3.5 shrink-0 ${sharedStatusConfig[suggestedStatus.value]?.className ?? ""}`}
+										/>
+									}
+									label={`Move to ${sharedStatusConfig[suggestedStatus.value]?.label ?? suggestedStatus.value}`}
+									title={suggestedStatus.reason}
+									onApply={r.applyStatus}
+									onDismiss={r.dismissStatus}
+								/>
+							</div>
+						</div>
+					)}
+
 					{suggestedCategory && (
 						<div className="flex flex-col gap-1.5">
 							<div className="flex flex-wrap items-center gap-2">
@@ -561,7 +604,8 @@ function hasAnyRecommendation(result: RecommendationsResult | null): boolean {
 		Boolean(result.priority) ||
 		Boolean(result.categoryId) ||
 		Boolean(result.releaseId) ||
-		result.relations.length > 0
+		result.relations.length > 0 ||
+		Boolean(result.status)
 	);
 }
 

--- a/apps/start/src/components/tasks/task/task-group-section-header.tsx
+++ b/apps/start/src/components/tasks/task/task-group-section-header.tsx
@@ -38,7 +38,7 @@ export function TaskGroupSectionHeader({
   return (
     <div
       className={cn(
-        "z-10 select-none group",
+        "z-10 select-none group rounded-xl",
         isSubGroup ? "bg-accent z-9" : "bg-muted z-10",
         isSticky ? "sticky" : "",
         headerStyle?.rootClassName,
@@ -49,7 +49,7 @@ export function TaskGroupSectionHeader({
     >
       <div
         className={cn(
-          "flex items-center justify-between px-4 py-1 relative overflow-hidden shrink-0 rounded-lg bg-card",
+          "flex items-center justify-between px-4 py-1 relative overflow-hidden shrink-0 rounded-xl bg-card",
           compact && "px-2 py-1.5",
           headerStyle?.getItemClassName?.(group.key),
           className,

--- a/apps/start/src/components/tasks/task/task-group-section-header.tsx
+++ b/apps/start/src/components/tasks/task/task-group-section-header.tsx
@@ -49,7 +49,7 @@ export function TaskGroupSectionHeader({
     >
       <div
         className={cn(
-          "flex items-center justify-between px-4 py-1 relative overflow-hidden shrink-0 rounded-lg",
+          "flex items-center justify-between px-4 py-1 relative overflow-hidden shrink-0 rounded-lg bg-card",
           compact && "px-2 py-1.5",
           headerStyle?.getItemClassName?.(group.key),
           className,

--- a/apps/start/src/components/tasks/views/unified-task-view.tsx
+++ b/apps/start/src/components/tasks/views/unified-task-view.tsx
@@ -16,7 +16,7 @@ import {
 import { useStateManagement } from "@repo/ui/hooks/useStateManagement.ts";
 import { cn } from "@repo/ui/lib/utils";
 import { useStore } from "@tanstack/react-store";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Loader from "@/components/loader";
 import { useTaskSelection } from "@/hooks/useTaskSelection";
 import { useTaskViewManager } from "@/hooks/useTaskViewManager";
@@ -150,12 +150,7 @@ export function UnifiedTaskView({
 	}, [tasks, filters, sortBy, sortDirection]);
 
 	const [collapsedSections, setCollapsedSections] = useState<Set<string>>(new Set());
-
-	// Reset collapsed sections when grouping changes
-	useEffect(() => {
-		setCollapsedSections(new Set());
-		void grouping;
-	}, [grouping]);
+	const groupedTasksRef = useRef<NestedTaskGroup[]>([]);
 
 	// SSE Handlers
 	const handlers: WSMessageHandler<ServerEventMessage> = {
@@ -347,6 +342,40 @@ export function UnifiedTaskView({
 			releases,
 		});
 	}, [filteredTasks, availableUsers, effectiveShowCompleted, grouping, subGrouping, categories, releases]);
+
+	// Latest groupedTasks for use inside the grouping-change effect below, without making
+	// that effect re-fire on every task/filter change (it should only reset on `grouping`/`subGrouping`).
+	groupedTasksRef.current = groupedTasks;
+
+	// Reset collapsed sections when grouping or sub-grouping changes, defaulting any empty group/sub-group to collapsed
+	// biome-ignore lint/correctness/useExhaustiveDependencies: intentionally only reset on `grouping`/`subGrouping` change; groupedTasksRef always holds the latest value
+	useEffect(() => {
+		// Sub-group ids aren't namespaced per parent group (e.g. "priority:urgent" is reused
+		// under every status group), so collapsedSections.has(id) is shared across siblings.
+		// Sum counts per id first so a non-empty sub-group elsewhere isn't collapsed just
+		// because a same-named sub-group under a different parent happens to be empty.
+		const subGroupTaskCounts = new Map<string, number>();
+		for (const group of groupedTasksRef.current) {
+			for (const subGroup of group.subGroups ?? []) {
+				subGroupTaskCounts.set(subGroup.id, (subGroupTaskCounts.get(subGroup.id) ?? 0) + subGroup.count);
+			}
+		}
+
+		const defaultCollapsed = new Set<string>();
+		for (const group of groupedTasksRef.current) {
+			if (group.subGroups && group.subGroups.length > 0) {
+				for (const subGroup of group.subGroups) {
+					if ((subGroupTaskCounts.get(subGroup.id) ?? 0) === 0) defaultCollapsed.add(subGroup.id);
+				}
+				if (group.subGroups.every((subGroup) => (subGroupTaskCounts.get(subGroup.id) ?? 0) === 0)) {
+					defaultCollapsed.add(group.id);
+				}
+			} else if (group.count === 0) {
+				defaultCollapsed.add(group.id);
+			}
+		}
+		setCollapsedSections(defaultCollapsed);
+	}, [grouping, subGrouping]);
 
 	// Compute the IDs of tasks that are actually visible (non-collapsed groups,
 	// completed tasks filtered out per showCompletedTasks). This is what

--- a/apps/start/src/components/tasks/views/unified-task-view.tsx
+++ b/apps/start/src/components/tasks/views/unified-task-view.tsx
@@ -2,16 +2,16 @@
 
 import type { schema, TeamPermissions } from "@repo/database";
 import {
-	GridBoardCells,
-	type GridBoardColumnData,
-	GridBoardColumnHeader,
-	GridBoardColumns,
-	type GridBoardDragEndEvent,
-	GridBoardItem,
-	GridBoardProvider,
-	type GridBoardRowData,
-	GridBoardRowHeader,
-	GridBoardRows,
+  GridBoardCells,
+  type GridBoardColumnData,
+  GridBoardColumnHeader,
+  GridBoardColumns,
+  type GridBoardDragEndEvent,
+  GridBoardItem,
+  GridBoardProvider,
+  type GridBoardRowData,
+  GridBoardRowHeader,
+  GridBoardRows,
 } from "@repo/ui/components/doras-ui/grid-board";
 import { useStateManagement } from "@repo/ui/hooks/useStateManagement.ts";
 import { cn } from "@repo/ui/lib/utils";
@@ -20,846 +20,980 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Loader from "@/components/loader";
 import { useTaskSelection } from "@/hooks/useTaskSelection";
 import { useTaskViewManager } from "@/hooks/useTaskViewManager";
-import { useWSMessageHandler, type WSMessageHandler } from "@/hooks/useWSMessageHandler";
+import {
+  useWSMessageHandler,
+  type WSMessageHandler,
+} from "@/hooks/useWSMessageHandler";
 import { updateTaskAction } from "@/lib/fetches/task";
 import type useServerEvents from "@/lib/serverEvents";
 import type { ServerEventMessage } from "@/lib/serverEvents";
 import { userPreferencesStore } from "@/lib/stores/user-preferences-store";
 import { useToastAction } from "@/lib/util";
 import {
-	getAssigneeBulkUpdatePayload,
-	getCategoryUpdatePayload,
-	getLabelBulkUpdatePayload,
-	getParentUpdatePayload,
-	getPriorityUpdatePayload,
-	getRelationUpdatePayload,
-	getReleaseUpdatePayload,
-	getStatusUpdatePayload,
+  getAssigneeBulkUpdatePayload,
+  getCategoryUpdatePayload,
+  getLabelBulkUpdatePayload,
+  getParentUpdatePayload,
+  getPriorityUpdatePayload,
+  getRelationUpdatePayload,
+  getReleaseUpdatePayload,
+  getStatusUpdatePayload,
 } from "../actions";
 import type { FieldUpdatePayload } from "../actions/types";
 import { applyFilters } from "../filter/filter-config";
 import { sortTasks } from "../filter/sort-config";
 import type { TaskGroup } from "../filter/types";
-import { applyNestedGrouping, type FieldPermissions, getTaskFieldPermissions, type NestedTaskGroup } from "../shared";
+import {
+  applyNestedGrouping,
+  type FieldPermissions,
+  getTaskFieldPermissions,
+  type NestedTaskGroup,
+} from "../shared";
 import { TaskDetailDialog } from "../task/task-detail-dialog";
 import { TaskGroupSectionHeader } from "../task/task-group-section-header";
 import { BulkActionBar, type BulkUpdateAddRemove } from "./bulk-action-bar";
 import { UnifiedTaskItem } from "./unified-task-item";
 
 interface UnifiedTaskViewProps {
-	tasks: schema.TaskWithLabels[];
-	setTasks: (newValue: schema.TaskWithLabels[]) => void;
-	serverEvents: ReturnType<typeof useServerEvents>;
-	availableUsers: schema.userType[];
-	availableLabels?: schema.labelType[];
-	organization?: schema.OrganizationWithMembers;
-	categories: schema.categoryType[];
-	releases?: schema.releaseType[];
-	compact?: boolean;
-	forceShowCompleted?: boolean;
-	/** When true, shows org badges on each task row (cross-org mode) */
-	personal?: boolean;
-	/** Optional views to pass when no org context is available */
-	views?: schema.savedViewType[];
-	/** Optional className override for the outermost wrapper div */
-	className?: string;
-	/** Called when the dialog opens/closes a task, so the parent can switch SSE channels */
-	onActiveDialogTaskChange?: (taskId: string | null) => void;
-	/** Per-org permissions map for cross-org views (e.g. /mine). When provided with accountId, enables field-level gating. */
-	permissionsByOrg?: Record<string, TeamPermissions>;
-	/** The current user's ID. Required alongside permissionsByOrg for field-level gating. */
-	accountId?: string;
-	overviewLayout?: boolean;
-	/** When false, hides the TaskGroupSectionHeader for each group. Defaults to true. */
-	showGroupHeaders?: boolean;
+  tasks: schema.TaskWithLabels[];
+  setTasks: (newValue: schema.TaskWithLabels[]) => void;
+  serverEvents: ReturnType<typeof useServerEvents>;
+  availableUsers: schema.userType[];
+  availableLabels?: schema.labelType[];
+  organization?: schema.OrganizationWithMembers;
+  categories: schema.categoryType[];
+  releases?: schema.releaseType[];
+  compact?: boolean;
+  forceShowCompleted?: boolean;
+  /** When true, shows org badges on each task row (cross-org mode) */
+  personal?: boolean;
+  /** Optional views to pass when no org context is available */
+  views?: schema.savedViewType[];
+  /** Optional className override for the outermost wrapper div */
+  className?: string;
+  /** Called when the dialog opens/closes a task, so the parent can switch SSE channels */
+  onActiveDialogTaskChange?: (taskId: string | null) => void;
+  /** Per-org permissions map for cross-org views (e.g. /mine). When provided with accountId, enables field-level gating. */
+  permissionsByOrg?: Record<string, TeamPermissions>;
+  /** The current user's ID. Required alongside permissionsByOrg for field-level gating. */
+  accountId?: string;
+  overviewLayout?: boolean;
+  /** When false, hides the TaskGroupSectionHeader for each group. Defaults to true. */
+  showGroupHeaders?: boolean;
 }
 
+// Sub-group ids aren't namespaced per parent group (e.g. every status group's Priority
+// sub-grouping produces the same "priority:urgent" id) — that's intentional, since Kanban's
+// row/column matrix relies on the same sub-group id matching across every column. List view's
+// collapse tracking needs per-parent uniqueness though, so it scopes its own key here instead
+// of touching subGroup.id itself.
+const getSubGroupCollapseKey = (
+  group: NestedTaskGroup,
+  subGroup: TaskGroup,
+): string => `${group.id}::${subGroup.id}`;
+
 export function UnifiedTaskView({
-	tasks,
-	setTasks,
-	serverEvents,
-	availableUsers = [],
-	availableLabels = [],
-	organization,
-	categories,
-	releases = [],
-	compact = false,
-	forceShowCompleted = false,
-	personal = false,
-	views: viewsProp,
-	className: classNameProp,
-	onActiveDialogTaskChange,
-	permissionsByOrg,
-	accountId,
-	overviewLayout = false,
-	showGroupHeaders = true,
+  tasks,
+  setTasks,
+  serverEvents,
+  availableUsers = [],
+  availableLabels = [],
+  organization,
+  categories,
+  releases = [],
+  compact = false,
+  forceShowCompleted = false,
+  personal = false,
+  views: viewsProp,
+  className: classNameProp,
+  onActiveDialogTaskChange,
+  permissionsByOrg,
+  accountId,
+  overviewLayout = false,
+  showGroupHeaders = true,
 }: UnifiedTaskViewProps) {
-	// console.log("[RENDER] UnifiedTaskView");
-	const [mounted, setMounted] = useState(false);
-
-	useEffect(() => {
-		setMounted(true);
-	}, []);
-
-	// Shared State
-	// Consolidated task view state management - pass views to enable auto-loading
-	const { filters, grouping, subGrouping, showCompletedTasks, viewMode, sortBy, sortDirection } =
-		useTaskViewManager(viewsProp);
-
-	// Override showCompletedTasks if forceShowCompleted is true
-	const effectiveShowCompleted = forceShowCompleted || showCompletedTasks;
-
-	const { runWithToast } = useToastAction();
-	const { value: sseClientId } = useStateManagement<string>("sse-clientId", "");
-
-	// Task open mode preference
-	const taskOpenMode = useStore(userPreferencesStore, (s) => s.taskOpenMode);
-	const [dialogTask, setDialogTask] = useState<schema.TaskWithLabels | null>(null);
-
-	const handleTaskClick = useCallback((task: schema.TaskWithLabels) => {
-		setDialogTask(task);
-	}, []);
-
-	const handleOpenInDialog = useCallback((task: schema.TaskWithLabels) => {
-		setDialogTask(task);
-	}, []);
-
-	// Notify parent when the active dialog task changes (for SSE channel switching)
-	useEffect(() => {
-		onActiveDialogTaskChange?.(dialogTask?.id ?? null);
-	}, [dialogTask?.id, onActiveDialogTaskChange]);
-
-	// Keep dialogTask in sync with the tasks array (real-time updates)
-	useEffect(() => {
-		if (dialogTask) {
-			const updated = tasks.find((t) => t.id === dialogTask.id);
-			if (updated && updated !== dialogTask) {
-				setDialogTask(updated);
-			}
-		}
-	}, [tasks, dialogTask]);
-
-	// List View Specific State
-	// Apply filters to tasks (used by both grouping and selection)
-	const filteredTasks = useMemo(() => {
-		// Every TASK_GROUPINGS grouping fn (shared/config.tsx) only pushes tasks
-		// in input order, so sorting once here — before grouping — is enough to
-		// sort within every group/sub-group without touching grouping itself.
-		const filtered = applyFilters(tasks, filters);
-		return sortTasks(filtered, sortBy === "none" ? undefined : sortBy, sortDirection);
-	}, [tasks, filters, sortBy, sortDirection]);
-
-	const [collapsedSections, setCollapsedSections] = useState<Set<string>>(new Set());
-	const groupedTasksRef = useRef<NestedTaskGroup[]>([]);
-
-	// SSE Handlers
-	const handlers: WSMessageHandler<ServerEventMessage> = {
-		UPDATE_TASK: (msg) => {
-			const updatedTask = msg.data;
-			const updatedTasks = tasks.map((task) => (task.id === updatedTask.id ? updatedTask : task));
-			setTasks(updatedTasks);
-		},
-	};
-
-	const handleMessage = useWSMessageHandler<ServerEventMessage>(handlers, {
-		// onUnhandled: (msg) =>
-		//   console.warn("⚠️ [UNHANDLED MESSAGE UnifiedTaskView]", msg),
-	});
-
-	useEffect(() => {
-		if (!serverEvents.event) return;
-		serverEvents.event.addEventListener("message", handleMessage);
-		return () => {
-			serverEvents.event?.removeEventListener("message", handleMessage);
-		};
-	}, [serverEvents.event, handleMessage]);
-
-	const handleToggleSection = (groupId: string) => {
-		const newCollapsed = new Set(collapsedSections);
-		if (newCollapsed.has(groupId)) {
-			newCollapsed.delete(groupId);
-		} else {
-			newCollapsed.add(groupId);
-		}
-		setCollapsedSections(newCollapsed);
-	};
-
-	// Lightweight dispatcher for FieldUpdatePayload — mirrors useTaskFieldAction.execute
-	// but operates on any task by ID rather than being bound to a single task instance.
-	const dispatchPayload = async (payload: FieldUpdatePayload) => {
-		switch (payload.kind) {
-			case "single": {
-				const orgId = payload.optimisticTask.organizationId;
-				await runWithToast(`update-task-${payload.field}`, payload.toastMessages, () =>
-					updateTaskAction(orgId, payload.optimisticTask.id, payload.updateData, sseClientId)
-				);
-				break;
-			}
-			case "multi":
-			case "parent": {
-				await runWithToast(payload.actionId, payload.toastMessages, payload.apiFn);
-				break;
-			}
-			case "relation": {
-				await runWithToast(payload.actionId, payload.toastMessages, payload.apiFn);
-				break;
-			}
-		}
-	};
-
-	const handleTaskUpdate = async (taskId: string, updates: Partial<schema.TaskWithLabels>) => {
-		// Optimistic update
-		const updatedTasks = tasks.map((t) => (t.id === taskId ? { ...t, ...updates } : t));
-		setTasks(updatedTasks);
-
-		// Look up the task to pass to payload generators
-		const task = tasks.find((t) => t.id === taskId);
-		if (!task) return;
-
-		if (updates.status) {
-			await dispatchPayload(getStatusUpdatePayload(task, updates.status));
-		}
-		if (updates.priority) {
-			await dispatchPayload(getPriorityUpdatePayload(task, updates.priority));
-		}
-		if (updates.assignees) {
-			await dispatchPayload(
-				getAssigneeBulkUpdatePayload(
-					task,
-					updates.assignees.map((u) => u.id),
-					availableUsers,
-					sseClientId
-				)
-			);
-		}
-		if (updates.labels) {
-			await dispatchPayload(
-				getLabelBulkUpdatePayload(
-					task,
-					updates.labels.map((l) => l.id),
-					availableLabels,
-					sseClientId
-				)
-			);
-		}
-		if (updates.category !== undefined) {
-			await dispatchPayload(getCategoryUpdatePayload(task, updates.category, categories));
-		}
-		if (updates.releaseId !== undefined) {
-			await dispatchPayload(getReleaseUpdatePayload(task, updates.releaseId, releases));
-		}
-		if (updates.parentId !== undefined) {
-			await dispatchPayload(
-				getParentUpdatePayload(task, updates.parentId, tasks, sseClientId, organization?.shortId)
-			);
-		}
-	};
-
-	const handleAddRelation = async (
-		sourceTaskId: string,
-		targetTaskId: string,
-		type: "related" | "blocking" | "duplicate"
-	) => {
-		const task = tasks.find((t) => t.id === sourceTaskId);
-		if (!task) return;
-		await dispatchPayload(
-			getRelationUpdatePayload(task, targetTaskId, type, tasks, sseClientId, organization?.shortId)
-		);
-	};
-
-	// Bulk update handler - iterates over selected tasks in parallel
-	const handleBulkUpdate = async (field: string, value: unknown) => {
-		const selectedIds = Array.from(selectedTasks);
-		if (selectedIds.length === 0) return;
-
-		// Build updates based on field
-		const getUpdatesForTask = (taskId: string): Partial<schema.TaskWithLabels> => {
-			const task = tasks.find((t) => t.id === taskId);
-			switch (field) {
-				case "status":
-					return { status: value as schema.TaskWithLabels["status"] };
-				case "priority":
-					return { priority: value as schema.TaskWithLabels["priority"] };
-				case "assignees": {
-					const { add, remove } = value as BulkUpdateAddRemove;
-					const existing = task?.assignees ?? [];
-					const existingIds = new Set(existing.map((a) => a.id));
-					// Add new assignees, remove unwanted ones
-					const finalIds = new Set(existingIds);
-					for (const id of add) finalIds.add(id);
-					for (const id of remove) finalIds.delete(id);
-					const users = availableUsers.filter((u) => finalIds.has(u.id));
-					return { assignees: users };
-				}
-				case "labels": {
-					const { add, remove } = value as BulkUpdateAddRemove;
-					const existing = task?.labels ?? [];
-					const existingIds = new Set(existing.map((l) => l.id));
-					// Add new labels, remove unwanted ones
-					const finalIds = new Set(existingIds);
-					for (const id of add) finalIds.add(id);
-					for (const id of remove) finalIds.delete(id);
-					const labels = availableLabels.filter((l) => finalIds.has(l.id));
-					return { labels };
-				}
-				case "category":
-					return { category: value as string };
-				case "release":
-					return { releaseId: value as string };
-				default:
-					return {};
-			}
-		};
-
-		// Optimistic update for all selected tasks
-		const updatedTasks = tasks.map((t) => {
-			if (!selectedTasks.has(t.id)) return t;
-			return { ...t, ...getUpdatesForTask(t.id) };
-		});
-		setTasks(updatedTasks);
-
-		// Fire API calls in parallel
-		const results = await Promise.allSettled(
-			selectedIds.map((taskId) => handleTaskUpdate(taskId, getUpdatesForTask(taskId)))
-		);
-
-		const failures = results.filter((r) => r.status === "rejected");
-		if (failures.length > 0) {
-			console.error(`Failed to update ${failures.length} task(s)`, failures);
-		}
-
-		// Clear selection after bulk action
-		deselectAll();
-	};
-
-	// Grouping Logic with nested sub-grouping support
-	const groupedTasks = useMemo((): NestedTaskGroup[] => {
-		return applyNestedGrouping(grouping, subGrouping, {
-			tasks: filteredTasks,
-			availableUsers,
-			showCompletedTasks: effectiveShowCompleted,
-			categories,
-			releases,
-		});
-	}, [filteredTasks, availableUsers, effectiveShowCompleted, grouping, subGrouping, categories, releases]);
-
-	// Latest groupedTasks for use inside the grouping-change effect below, without making
-	// that effect re-fire on every task/filter change (it should only reset on `grouping`/`subGrouping`).
-	groupedTasksRef.current = groupedTasks;
-
-	// Reset collapsed sections when grouping or sub-grouping changes, defaulting any empty group/sub-group to collapsed
-	// biome-ignore lint/correctness/useExhaustiveDependencies: intentionally only reset on `grouping`/`subGrouping` change; groupedTasksRef always holds the latest value
-	useEffect(() => {
-		// Sub-group ids aren't namespaced per parent group (e.g. "priority:urgent" is reused
-		// under every status group), so collapsedSections.has(id) is shared across siblings.
-		// Sum counts per id first so a non-empty sub-group elsewhere isn't collapsed just
-		// because a same-named sub-group under a different parent happens to be empty.
-		const subGroupTaskCounts = new Map<string, number>();
-		for (const group of groupedTasksRef.current) {
-			for (const subGroup of group.subGroups ?? []) {
-				subGroupTaskCounts.set(subGroup.id, (subGroupTaskCounts.get(subGroup.id) ?? 0) + subGroup.count);
-			}
-		}
-
-		const defaultCollapsed = new Set<string>();
-		for (const group of groupedTasksRef.current) {
-			if (group.subGroups && group.subGroups.length > 0) {
-				for (const subGroup of group.subGroups) {
-					if ((subGroupTaskCounts.get(subGroup.id) ?? 0) === 0) defaultCollapsed.add(subGroup.id);
-				}
-				if (group.subGroups.every((subGroup) => (subGroupTaskCounts.get(subGroup.id) ?? 0) === 0)) {
-					defaultCollapsed.add(group.id);
-				}
-			} else if (group.count === 0) {
-				defaultCollapsed.add(group.id);
-			}
-		}
-		setCollapsedSections(defaultCollapsed);
-	}, [grouping, subGrouping]);
-
-	// Compute the IDs of tasks that are actually visible (non-collapsed groups,
-	// completed tasks filtered out per showCompletedTasks). This is what
-	// "select all" should be scoped to.
-	const visibleTaskIds = useMemo(() => {
-		const ids: string[] = [];
-		for (const group of groupedTasks) {
-			if (collapsedSections.has(group.id)) continue;
-			if (group.subGroups) {
-				for (const subGroup of group.subGroups) {
-					if (collapsedSections.has(subGroup.id)) continue;
-					for (const task of subGroup.tasks) ids.push(task.id);
-				}
-			} else {
-				for (const task of group.tasks) ids.push(task.id);
-			}
-		}
-		return ids;
-	}, [groupedTasks, collapsedSections]);
-
-	const {
-		selectedSet: selectedTasks,
-		selectedCount,
-		toggleTask,
-		selectAll,
-		deselectAll,
-		isAllSelected,
-		isIndeterminate,
-	} = useTaskSelection(visibleTaskIds);
-
-	// Resolve selected task objects for the bulk action bar
-	const selectedTaskData = useMemo(() => {
-		return tasks.filter((t) => selectedTasks.has(t.id));
-	}, [tasks, selectedTasks]);
-
-	// Handlers
-	const handleTaskSelect = useCallback(
-		(taskId: string, selected: boolean) => {
-			toggleTask(taskId, selected);
-		},
-		[toggleTask]
-	);
-
-	// Clear selection on unmount
-	useEffect(() => {
-		return () => {
-			deselectAll();
-		};
-	}, [deselectAll]);
-
-	// Check if we have sub-groups for kanban view
-	const hasKanbanSubGroups =
-		groupedTasks.length > 0 && groupedTasks[0]?.subGroups && groupedTasks[0].subGroups.length > 0;
-
-	// ============================================================================
-	// Render Functions
-	// ============================================================================
-
-	const renderLoading = () => <Loader />;
-
-	const renderTaskItem = (
-		task: schema.TaskWithLabels,
-		groupId: string,
-		mode: "list" | "kanban",
-		columnId?: string
-	) => {
-		// Compute field permissions when cross-org permission data is available
-		const fieldPerms: FieldPermissions | undefined =
-			permissionsByOrg && accountId
-				? getTaskFieldPermissions(task, accountId, permissionsByOrg[task.organizationId])
-				: undefined;
-
-		return (
-			<UnifiedTaskItem
-				key={`${groupId}:${task.id}`}
-				viewMode={mode}
-				task={task}
-				columnId={columnId}
-				isSelected={mode === "list" ? selectedTasks.has(task.id) : undefined}
-				onSelect={mode === "list" ? (selected) => handleTaskSelect(task.id, selected) : undefined}
-				tasks={tasks}
-				setTasks={setTasks}
-				availableUsers={availableUsers}
-				availableLabels={availableLabels}
-				onTaskUpdate={handleTaskUpdate}
-				onTaskClick={taskOpenMode === "dialog" ? handleTaskClick : undefined}
-				onOpenInDialog={handleOpenInDialog}
-				onAddRelation={handleAddRelation}
-				categories={categories}
-				releases={releases}
-				compact={compact}
-				overviewLayout={overviewLayout}
-				personal={personal}
-				fieldPermissions={fieldPerms}
-				organization={organization}
-				className={cn(overviewLayout ? "bg-accent hover:bg-secondary! rounded-xl mb-1" : undefined)}
-			/>
-		);
-	};
-
-	const renderEmptyGroup = () =>
-		showGroupHeaders ? <div className="px-4 py-3 text-xs text-muted-foreground">No tasks in this group</div> : null;
-
-	const renderEmptyState = () => <div className="flex items-center justify-center">No issues found</div>;
-
-	const renderKanbanView = () => {
-		// Transform groupedTasks into GridBoard columns
-		const gridColumns: GridBoardColumnData[] = groupedTasks.map((group) => ({
-			id: group.id,
-			label: group.label,
-			count: group.count,
-			icon: group.icon,
-			accentClassName: group.accentClassName,
-		}));
-
-		// Transform subGroups into GridBoard rows (if they exist)
-		const gridRows: GridBoardRowData[] | undefined = hasKanbanSubGroups
-			? groupedTasks[0]?.subGroups?.map((sg) => ({
-					id: sg.id,
-					label: sg.label,
-					icon: sg.icon,
-					accentClassName: sg.accentClassName,
-				}))
-			: undefined;
-
-		// Build a flat list of items with columnId and rowId for GridBoard
-		type GridItem = schema.TaskWithLabels & {
-			columnId: string;
-			rowId?: string;
-		};
-		const gridItems: GridItem[] = [];
-
-		for (const group of groupedTasks) {
-			if (hasKanbanSubGroups && group.subGroups) {
-				for (const subGroup of group.subGroups) {
-					for (const task of subGroup.tasks) {
-						gridItems.push({ ...task, columnId: group.id, rowId: subGroup.id });
-					}
-				}
-			} else {
-				for (const task of group.tasks) {
-					gridItems.push({ ...task, columnId: group.id });
-				}
-			}
-		}
-
-		// Custom getItemsForCell to look up tasks by column/row
-		const getItemsForCell = (columnId: string, rowId?: string): GridItem[] => {
-			const group = groupedTasks.find((g) => g.id === columnId);
-			if (!group) return [];
-
-			if (rowId !== undefined && group.subGroups) {
-				const subGroup = group.subGroups.find((sg) => sg.id === rowId);
-				return (subGroup?.tasks || []).map((t) => ({ ...t, columnId, rowId }));
-			}
-			return group.tasks.map((t) => ({ ...t, columnId }));
-		};
-
-		// Calculate row totals for row headers
-		const getRowTotal = (rowId: string): number => {
-			return gridColumns.reduce((sum, col) => sum + getItemsForCell(col.id, rowId).length, 0);
-		};
-
-		// Handle drag end - update both column (primary grouping) and row (sub-grouping)
-		const handleGridDragEnd = async (event: GridBoardDragEndEvent<GridItem>) => {
-			const { item, toColumnId, toRowId } = event;
-			const itemId = item.id;
-
-			// Helper to update local state optimistically
-			const updateLocal = (updates: Partial<schema.TaskWithLabels>) => {
-				const updatedTasks = tasks.map((t) => (t.id === itemId ? { ...t, ...updates } : t));
-				setTasks(updatedTasks);
-			};
-
-			// Helper to extract the actual value from prefixed IDs like "status:backlog" -> "backlog"
-			const extractValue = (id: string, prefix: string): string | null => {
-				if (id.startsWith(`${prefix}:`)) {
-					return id.slice(prefix.length + 1);
-				}
-				return null;
-			};
-
-			// Determine what fields to update based on grouping/subGrouping
-			const updates: Partial<schema.TaskWithLabels> = {};
-
-			// Handle column change (primary grouping)
-			if (grouping === "status") {
-				const status = extractValue(toColumnId, "status");
-				if (status) {
-					updates.status = status as schema.TaskWithLabels["status"];
-				}
-			} else if (grouping === "priority") {
-				const priority = extractValue(toColumnId, "priority");
-				if (priority) {
-					updates.priority = priority as schema.TaskWithLabels["priority"];
-				}
-			} else if (grouping === "assignee") {
-				const assigneeId = extractValue(toColumnId, "assignee");
-				if (assigneeId === "unassigned") {
-					updates.assignees = [];
-				} else if (assigneeId) {
-					const user = availableUsers.find((u) => u.id === assigneeId);
-					if (user) updates.assignees = [user];
-				}
-			} else if (grouping === "category") {
-				const categoryId = extractValue(toColumnId, "category");
-				if (categoryId === "none") {
-					updates.category = null;
-				} else if (categoryId) {
-					updates.category = categoryId;
-				}
-			}
-
-			// Handle row change (sub-grouping)
-			if (toRowId !== undefined) {
-				if (subGrouping === "status") {
-					const status = extractValue(toRowId, "status");
-					if (status) {
-						updates.status = status as schema.TaskWithLabels["status"];
-					}
-				} else if (subGrouping === "priority") {
-					const priority = extractValue(toRowId, "priority");
-					if (priority) {
-						updates.priority = priority as schema.TaskWithLabels["priority"];
-					}
-				} else if (subGrouping === "assignee") {
-					const assigneeId = extractValue(toRowId, "assignee");
-					if (assigneeId === "unassigned") {
-						updates.assignees = [];
-					} else if (assigneeId) {
-						const user = availableUsers.find((u) => u.id === assigneeId);
-						if (user) updates.assignees = [user];
-					}
-				} else if (subGrouping === "category") {
-					const categoryId = extractValue(toRowId, "category");
-					if (categoryId === "none") {
-						updates.category = null;
-					} else if (categoryId) {
-						updates.category = categoryId;
-					}
-				}
-			}
-
-			// Check if there are any updates to apply
-			if (Object.keys(updates).length === 0) {
-				// console.log("[GridBoard] No updates to apply", {
-				//   toColumnId,
-				//   toRowId,
-				//   grouping,
-				//   subGrouping,
-				// });
-				return;
-			}
-
-			// console.log("[GridBoard] Applying updates", {
-			//   itemId,
-			//   updates,
-			//   toColumnId,
-			//   toRowId,
-			// });
-
-			// Apply optimistic update
-			updateLocal(updates);
-
-			// Look up the task to pass to payload generators
-			const task = tasks.find((t) => t.id === itemId);
-			if (!task) return;
-
-			// Send updates to server via action system
-			if (updates.status) {
-				await dispatchPayload(getStatusUpdatePayload(task, updates.status));
-			}
-
-			if (updates.priority) {
-				await dispatchPayload(getPriorityUpdatePayload(task, updates.priority));
-			}
-
-			if (updates.assignees !== undefined) {
-				await dispatchPayload(
-					getAssigneeBulkUpdatePayload(
-						task,
-						updates.assignees.map((u) => u.id),
-						availableUsers,
-						sseClientId
-					)
-				);
-			}
-
-			if (updates.category !== undefined) {
-				await dispatchPayload(getCategoryUpdatePayload(task, updates.category, categories));
-			}
-		};
-
-		// Render drag overlay
-		const renderDragOverlay = (item: GridItem) => {
-			const dragFieldPerms: FieldPermissions | undefined =
-				permissionsByOrg && accountId
-					? getTaskFieldPermissions(item, accountId, permissionsByOrg[item.organizationId])
-					: undefined;
-
-			return (
-				<div className="opacity-90 rotate-2 scale-105">
-					<UnifiedTaskItem
-						viewMode="kanban"
-						task={item}
-						columnId={item.columnId}
-						tasks={tasks}
-						setTasks={setTasks}
-						availableUsers={availableUsers}
-						availableLabels={availableLabels}
-						onTaskUpdate={handleTaskUpdate}
-						onAddRelation={handleAddRelation}
-						categories={categories}
-						releases={releases}
-						compact={compact}
-						personal={personal}
-						fieldPermissions={dragFieldPerms}
-						organization={organization}
-					/>
-				</div>
-			);
-		};
-
-		return (
-			<GridBoardProvider
-				columns={gridColumns}
-				rows={gridRows}
-				items={gridItems}
-				getItemsForCell={getItemsForCell}
-				onDragEnd={handleGridDragEnd}
-				renderDragOverlay={renderDragOverlay}
-				mode={hasKanbanSubGroups ? "grid" : "kanban"}
-			>
-				{/* Column Headers */}
-				<GridBoardColumns>{(column) => <GridBoardColumnHeader key={column.id} column={column} />}</GridBoardColumns>
-
-				{/* Rows with cells (if sub-groups exist) */}
-				{hasKanbanSubGroups && gridRows ? (
-					<GridBoardRows>
-						{(row) => (
-							<div key={row.id}>
-								<GridBoardRowHeader row={row} count={getRowTotal(row.id)} />
-								<GridBoardCells rowId={row.id}>
-									{(item: GridItem, column) => (
-										<GridBoardItem key={item.id} item={item}>
-											{renderTaskItem(item, column.id, "kanban", column.id)}
-										</GridBoardItem>
-									)}
-								</GridBoardCells>
-							</div>
-						)}
-					</GridBoardRows>
-				) : (
-					/* No sub-groups: render cells directly (kanban mode) */
-					<GridBoardCells>
-						{(item: GridItem, column) => (
-							<GridBoardItem key={item.id} item={item}>
-								{renderTaskItem(item, column.id, "kanban", column.id)}
-							</GridBoardItem>
-						)}
-					</GridBoardCells>
-				)}
-			</GridBoardProvider>
-		);
-	};
-
-	const renderListSubGroup = (group: NestedTaskGroup, subGroup: TaskGroup) => {
-		const subGroupCollapsed = collapsedSections.has(subGroup.id);
-
-		return (
-			<div key={subGroup.id}>
-				{showGroupHeaders && (
-					<TaskGroupSectionHeader
-						group={subGroup}
-						isCollapsed={subGroupCollapsed}
-						onToggleCollapse={() => handleToggleSection(subGroup.id)}
-						isSubGroup={true}
-						className="py-1"
-						rootClassName="bg-muted/0 hover:bg-muted/20 transition-all"
-						compact={compact}
-					/>
-				)}
-				{!subGroupCollapsed && (
-					<div className="py-1 flex flex-col gap-1">
-						{subGroup.tasks.length > 0
-							? subGroup.tasks.map((task) => renderTaskItem(task, group.id, "list"))
-							: renderEmptyGroup()}
-					</div>
-				)}
-			</div>
-		);
-	};
-
-	const renderListGroup = (group: NestedTaskGroup) => {
-		const isCollapsed = collapsedSections.has(group.id);
-		const hasSubGroups = group.subGroups && group.subGroups.length > 0;
-
-		const renderGroupContent = () => {
-			if (hasSubGroups && group.subGroups) {
-				return group.subGroups.map((subGroup) => renderListSubGroup(group, subGroup));
-			}
-			if (group.tasks.length > 0) {
-				return group.tasks.map((task) => renderTaskItem(task, group.id, "list"));
-			}
-			return renderEmptyGroup();
-		};
-
-		return (
-			<div key={group.id}>
-				{showGroupHeaders && (
-					<TaskGroupSectionHeader
-						group={group}
-						isCollapsed={isCollapsed}
-						onToggleCollapse={() => handleToggleSection(group.id)}
-						isSticky={true}
-						compact={compact}
-					/>
-				)}
-				{!isCollapsed && <div className="flex flex-col gap-0">{renderGroupContent()}</div>}
-			</div>
-		);
-	};
-
-	const renderListView = () => {
-		if (groupedTasks.length === 0) {
-			return renderEmptyState();
-		}
-		return <div className={cn("rounded h-full", compact && "px-0")}>{groupedTasks.map(renderListGroup)}</div>;
-	};
-
-	const renderMainContent = () => {
-		if (viewMode === "kanban") {
-			// Always use GridBoard for kanban - mode is set based on hasKanbanSubGroups
-			return renderKanbanView();
-		}
-		return renderListView();
-	};
-
-	// ============================================================================
-	// Main Return
-	// ============================================================================
-
-	if (!mounted) {
-		return renderLoading();
-	}
-	const smallViewport = window.innerWidth < 1000;
-	return (
-		<div className={cn("h-full overflow-auto rounded", classNameProp)}>
-			{renderMainContent()}
-			{!compact && (
-				<BulkActionBar
-					selectedCount={selectedCount}
-					selectedTasks={selectedTaskData}
-					visible={selectedCount > 0 && viewMode === "list"}
-					onDeselectAll={deselectAll}
-					onSelectAll={() => selectAll(visibleTaskIds)}
-					isAllSelected={isAllSelected}
-					isIndeterminate={isIndeterminate}
-					onBulkUpdate={handleBulkUpdate}
-					availableUsers={availableUsers}
-					availableLabels={availableLabels}
-					categories={categories}
-					releases={releases}
-					compact={smallViewport}
-				/>
-			)}
-			<TaskDetailDialog
-				task={dialogTask}
-				open={dialogTask !== null}
-				onOpenChange={(open) => {
-					if (!open) setDialogTask(null);
-				}}
-				tasks={tasks}
-				setTasks={setTasks}
-				labels={availableLabels}
-				categories={categories}
-				releases={releases}
-				organization={organization}
-				fieldPermissions={
-					dialogTask && permissionsByOrg && accountId
-						? getTaskFieldPermissions(dialogTask, accountId, permissionsByOrg[dialogTask.organizationId])
-						: undefined
-				}
-			/>
-		</div>
-	);
+  // console.log("[RENDER] UnifiedTaskView");
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  // Shared State
+  // Consolidated task view state management - pass views to enable auto-loading
+  const {
+    filters,
+    grouping,
+    subGrouping,
+    showCompletedTasks,
+    viewMode,
+    sortBy,
+    sortDirection,
+  } = useTaskViewManager(viewsProp);
+
+  // Override showCompletedTasks if forceShowCompleted is true
+  const effectiveShowCompleted = forceShowCompleted || showCompletedTasks;
+
+  const { runWithToast } = useToastAction();
+  const { value: sseClientId } = useStateManagement<string>("sse-clientId", "");
+
+  // Task open mode preference
+  const taskOpenMode = useStore(userPreferencesStore, (s) => s.taskOpenMode);
+  const [dialogTask, setDialogTask] = useState<schema.TaskWithLabels | null>(
+    null,
+  );
+
+  const handleTaskClick = useCallback((task: schema.TaskWithLabels) => {
+    setDialogTask(task);
+  }, []);
+
+  const handleOpenInDialog = useCallback((task: schema.TaskWithLabels) => {
+    setDialogTask(task);
+  }, []);
+
+  // Notify parent when the active dialog task changes (for SSE channel switching)
+  useEffect(() => {
+    onActiveDialogTaskChange?.(dialogTask?.id ?? null);
+  }, [dialogTask?.id, onActiveDialogTaskChange]);
+
+  // Keep dialogTask in sync with the tasks array (real-time updates)
+  useEffect(() => {
+    if (dialogTask) {
+      const updated = tasks.find((t) => t.id === dialogTask.id);
+      if (updated && updated !== dialogTask) {
+        setDialogTask(updated);
+      }
+    }
+  }, [tasks, dialogTask]);
+
+  // List View Specific State
+  // Apply filters to tasks (used by both grouping and selection)
+  const filteredTasks = useMemo(() => {
+    // Every TASK_GROUPINGS grouping fn (shared/config.tsx) only pushes tasks
+    // in input order, so sorting once here — before grouping — is enough to
+    // sort within every group/sub-group without touching grouping itself.
+    const filtered = applyFilters(tasks, filters);
+    return sortTasks(
+      filtered,
+      sortBy === "none" ? undefined : sortBy,
+      sortDirection,
+    );
+  }, [tasks, filters, sortBy, sortDirection]);
+
+  const [collapsedSections, setCollapsedSections] = useState<Set<string>>(
+    new Set(),
+  );
+  const groupedTasksRef = useRef<NestedTaskGroup[]>([]);
+
+  // SSE Handlers
+  const handlers: WSMessageHandler<ServerEventMessage> = {
+    UPDATE_TASK: (msg) => {
+      const updatedTask = msg.data;
+      const updatedTasks = tasks.map((task) =>
+        task.id === updatedTask.id ? updatedTask : task,
+      );
+      setTasks(updatedTasks);
+    },
+  };
+
+  const handleMessage = useWSMessageHandler<ServerEventMessage>(handlers, {
+    // onUnhandled: (msg) =>
+    //   console.warn("⚠️ [UNHANDLED MESSAGE UnifiedTaskView]", msg),
+  });
+
+  useEffect(() => {
+    if (!serverEvents.event) return;
+    serverEvents.event.addEventListener("message", handleMessage);
+    return () => {
+      serverEvents.event?.removeEventListener("message", handleMessage);
+    };
+  }, [serverEvents.event, handleMessage]);
+
+  const handleToggleSection = (groupId: string) => {
+    const newCollapsed = new Set(collapsedSections);
+    if (newCollapsed.has(groupId)) {
+      newCollapsed.delete(groupId);
+    } else {
+      newCollapsed.add(groupId);
+    }
+    setCollapsedSections(newCollapsed);
+  };
+
+  // Lightweight dispatcher for FieldUpdatePayload — mirrors useTaskFieldAction.execute
+  // but operates on any task by ID rather than being bound to a single task instance.
+  const dispatchPayload = async (payload: FieldUpdatePayload) => {
+    switch (payload.kind) {
+      case "single": {
+        const orgId = payload.optimisticTask.organizationId;
+        await runWithToast(
+          `update-task-${payload.field}`,
+          payload.toastMessages,
+          () =>
+            updateTaskAction(
+              orgId,
+              payload.optimisticTask.id,
+              payload.updateData,
+              sseClientId,
+            ),
+        );
+        break;
+      }
+      case "multi":
+      case "parent": {
+        await runWithToast(
+          payload.actionId,
+          payload.toastMessages,
+          payload.apiFn,
+        );
+        break;
+      }
+      case "relation": {
+        await runWithToast(
+          payload.actionId,
+          payload.toastMessages,
+          payload.apiFn,
+        );
+        break;
+      }
+    }
+  };
+
+  const handleTaskUpdate = async (
+    taskId: string,
+    updates: Partial<schema.TaskWithLabels>,
+  ) => {
+    // Optimistic update
+    const updatedTasks = tasks.map((t) =>
+      t.id === taskId ? { ...t, ...updates } : t,
+    );
+    setTasks(updatedTasks);
+
+    // Look up the task to pass to payload generators
+    const task = tasks.find((t) => t.id === taskId);
+    if (!task) return;
+
+    if (updates.status) {
+      await dispatchPayload(getStatusUpdatePayload(task, updates.status));
+    }
+    if (updates.priority) {
+      await dispatchPayload(getPriorityUpdatePayload(task, updates.priority));
+    }
+    if (updates.assignees) {
+      await dispatchPayload(
+        getAssigneeBulkUpdatePayload(
+          task,
+          updates.assignees.map((u) => u.id),
+          availableUsers,
+          sseClientId,
+        ),
+      );
+    }
+    if (updates.labels) {
+      await dispatchPayload(
+        getLabelBulkUpdatePayload(
+          task,
+          updates.labels.map((l) => l.id),
+          availableLabels,
+          sseClientId,
+        ),
+      );
+    }
+    if (updates.category !== undefined) {
+      await dispatchPayload(
+        getCategoryUpdatePayload(task, updates.category, categories),
+      );
+    }
+    if (updates.releaseId !== undefined) {
+      await dispatchPayload(
+        getReleaseUpdatePayload(task, updates.releaseId, releases),
+      );
+    }
+    if (updates.parentId !== undefined) {
+      await dispatchPayload(
+        getParentUpdatePayload(
+          task,
+          updates.parentId,
+          tasks,
+          sseClientId,
+          organization?.shortId,
+        ),
+      );
+    }
+  };
+
+  const handleAddRelation = async (
+    sourceTaskId: string,
+    targetTaskId: string,
+    type: "related" | "blocking" | "duplicate",
+  ) => {
+    const task = tasks.find((t) => t.id === sourceTaskId);
+    if (!task) return;
+    await dispatchPayload(
+      getRelationUpdatePayload(
+        task,
+        targetTaskId,
+        type,
+        tasks,
+        sseClientId,
+        organization?.shortId,
+      ),
+    );
+  };
+
+  // Bulk update handler - iterates over selected tasks in parallel
+  const handleBulkUpdate = async (field: string, value: unknown) => {
+    const selectedIds = Array.from(selectedTasks);
+    if (selectedIds.length === 0) return;
+
+    // Build updates based on field
+    const getUpdatesForTask = (
+      taskId: string,
+    ): Partial<schema.TaskWithLabels> => {
+      const task = tasks.find((t) => t.id === taskId);
+      switch (field) {
+        case "status":
+          return { status: value as schema.TaskWithLabels["status"] };
+        case "priority":
+          return { priority: value as schema.TaskWithLabels["priority"] };
+        case "assignees": {
+          const { add, remove } = value as BulkUpdateAddRemove;
+          const existing = task?.assignees ?? [];
+          const existingIds = new Set(existing.map((a) => a.id));
+          // Add new assignees, remove unwanted ones
+          const finalIds = new Set(existingIds);
+          for (const id of add) finalIds.add(id);
+          for (const id of remove) finalIds.delete(id);
+          const users = availableUsers.filter((u) => finalIds.has(u.id));
+          return { assignees: users };
+        }
+        case "labels": {
+          const { add, remove } = value as BulkUpdateAddRemove;
+          const existing = task?.labels ?? [];
+          const existingIds = new Set(existing.map((l) => l.id));
+          // Add new labels, remove unwanted ones
+          const finalIds = new Set(existingIds);
+          for (const id of add) finalIds.add(id);
+          for (const id of remove) finalIds.delete(id);
+          const labels = availableLabels.filter((l) => finalIds.has(l.id));
+          return { labels };
+        }
+        case "category":
+          return { category: value as string };
+        case "release":
+          return { releaseId: value as string };
+        default:
+          return {};
+      }
+    };
+
+    // Optimistic update for all selected tasks
+    const updatedTasks = tasks.map((t) => {
+      if (!selectedTasks.has(t.id)) return t;
+      return { ...t, ...getUpdatesForTask(t.id) };
+    });
+    setTasks(updatedTasks);
+
+    // Fire API calls in parallel
+    const results = await Promise.allSettled(
+      selectedIds.map((taskId) =>
+        handleTaskUpdate(taskId, getUpdatesForTask(taskId)),
+      ),
+    );
+
+    const failures = results.filter((r) => r.status === "rejected");
+    if (failures.length > 0) {
+      console.error(`Failed to update ${failures.length} task(s)`, failures);
+    }
+
+    // Clear selection after bulk action
+    deselectAll();
+  };
+
+  // Grouping Logic with nested sub-grouping support
+  const groupedTasks = useMemo((): NestedTaskGroup[] => {
+    return applyNestedGrouping(grouping, subGrouping, {
+      tasks: filteredTasks,
+      availableUsers,
+      showCompletedTasks: effectiveShowCompleted,
+      categories,
+      releases,
+    });
+  }, [
+    filteredTasks,
+    availableUsers,
+    effectiveShowCompleted,
+    grouping,
+    subGrouping,
+    categories,
+    releases,
+  ]);
+
+  // Latest groupedTasks for use inside the grouping-change effect below, without making
+  // that effect re-fire on every task/filter change (it should only reset on `grouping`/`subGrouping`).
+  groupedTasksRef.current = groupedTasks;
+
+  // Reset collapsed sections when grouping or sub-grouping changes, defaulting any empty group/sub-group to collapsed
+  // biome-ignore lint/correctness/useExhaustiveDependencies: intentionally only reset on `grouping`/`subGrouping` change; groupedTasksRef always holds the latest value
+  useEffect(() => {
+    const defaultCollapsed = new Set<string>();
+    for (const group of groupedTasksRef.current) {
+      if (group.subGroups && group.subGroups.length > 0) {
+        for (const subGroup of group.subGroups) {
+          if (subGroup.count === 0)
+            defaultCollapsed.add(getSubGroupCollapseKey(group, subGroup));
+        }
+        if (group.subGroups.every((subGroup) => subGroup.count === 0)) {
+          defaultCollapsed.add(group.id);
+        }
+      } else if (group.count === 0) {
+        defaultCollapsed.add(group.id);
+      }
+    }
+    setCollapsedSections(defaultCollapsed);
+  }, [grouping, subGrouping]);
+
+  // Compute the IDs of tasks that are actually visible (non-collapsed groups,
+  // completed tasks filtered out per showCompletedTasks). This is what
+  // "select all" should be scoped to.
+  const visibleTaskIds = useMemo(() => {
+    const ids: string[] = [];
+    for (const group of groupedTasks) {
+      if (collapsedSections.has(group.id)) continue;
+      if (group.subGroups) {
+        for (const subGroup of group.subGroups) {
+          if (collapsedSections.has(getSubGroupCollapseKey(group, subGroup)))
+            continue;
+          for (const task of subGroup.tasks) ids.push(task.id);
+        }
+      } else {
+        for (const task of group.tasks) ids.push(task.id);
+      }
+    }
+    return ids;
+  }, [groupedTasks, collapsedSections]);
+
+  const {
+    selectedSet: selectedTasks,
+    selectedCount,
+    toggleTask,
+    selectAll,
+    deselectAll,
+    isAllSelected,
+    isIndeterminate,
+  } = useTaskSelection(visibleTaskIds);
+
+  // Resolve selected task objects for the bulk action bar
+  const selectedTaskData = useMemo(() => {
+    return tasks.filter((t) => selectedTasks.has(t.id));
+  }, [tasks, selectedTasks]);
+
+  // Handlers
+  const handleTaskSelect = useCallback(
+    (taskId: string, selected: boolean) => {
+      toggleTask(taskId, selected);
+    },
+    [toggleTask],
+  );
+
+  // Clear selection on unmount
+  useEffect(() => {
+    return () => {
+      deselectAll();
+    };
+  }, [deselectAll]);
+
+  // Check if we have sub-groups for kanban view
+  const hasKanbanSubGroups =
+    groupedTasks.length > 0 &&
+    groupedTasks[0]?.subGroups &&
+    groupedTasks[0].subGroups.length > 0;
+
+  // ============================================================================
+  // Render Functions
+  // ============================================================================
+
+  const renderLoading = () => <Loader />;
+
+  const renderTaskItem = (
+    task: schema.TaskWithLabels,
+    groupId: string,
+    mode: "list" | "kanban",
+    columnId?: string,
+  ) => {
+    // Compute field permissions when cross-org permission data is available
+    const fieldPerms: FieldPermissions | undefined =
+      permissionsByOrg && accountId
+        ? getTaskFieldPermissions(
+            task,
+            accountId,
+            permissionsByOrg[task.organizationId],
+          )
+        : undefined;
+
+    return (
+      <UnifiedTaskItem
+        key={`${groupId}:${task.id}`}
+        viewMode={mode}
+        task={task}
+        columnId={columnId}
+        isSelected={mode === "list" ? selectedTasks.has(task.id) : undefined}
+        onSelect={
+          mode === "list"
+            ? (selected) => handleTaskSelect(task.id, selected)
+            : undefined
+        }
+        tasks={tasks}
+        setTasks={setTasks}
+        availableUsers={availableUsers}
+        availableLabels={availableLabels}
+        onTaskUpdate={handleTaskUpdate}
+        onTaskClick={taskOpenMode === "dialog" ? handleTaskClick : undefined}
+        onOpenInDialog={handleOpenInDialog}
+        onAddRelation={handleAddRelation}
+        categories={categories}
+        releases={releases}
+        compact={compact}
+        overviewLayout={overviewLayout}
+        personal={personal}
+        fieldPermissions={fieldPerms}
+        organization={organization}
+        className={cn(
+          overviewLayout
+            ? "bg-accent hover:bg-secondary! rounded-xl mb-1"
+            : undefined,
+        )}
+      />
+    );
+  };
+
+  const renderEmptyGroup = () =>
+    showGroupHeaders ? (
+      <div className="px-4 py-3 text-xs text-muted-foreground">
+        No tasks in this group
+      </div>
+    ) : null;
+
+  const renderEmptyState = () => (
+    <div className="flex items-center justify-center">No issues found</div>
+  );
+
+  const renderKanbanView = () => {
+    // Transform groupedTasks into GridBoard columns
+    const gridColumns: GridBoardColumnData[] = groupedTasks.map((group) => ({
+      id: group.id,
+      label: group.label,
+      count: group.count,
+      icon: group.icon,
+      accentClassName: group.accentClassName,
+    }));
+
+    // Transform subGroups into GridBoard rows (if they exist)
+    const gridRows: GridBoardRowData[] | undefined = hasKanbanSubGroups
+      ? groupedTasks[0]?.subGroups?.map((sg) => ({
+          id: sg.id,
+          label: sg.label,
+          icon: sg.icon,
+          accentClassName: sg.accentClassName,
+        }))
+      : undefined;
+
+    // Build a flat list of items with columnId and rowId for GridBoard
+    type GridItem = schema.TaskWithLabels & {
+      columnId: string;
+      rowId?: string;
+    };
+    const gridItems: GridItem[] = [];
+
+    for (const group of groupedTasks) {
+      if (hasKanbanSubGroups && group.subGroups) {
+        for (const subGroup of group.subGroups) {
+          for (const task of subGroup.tasks) {
+            gridItems.push({ ...task, columnId: group.id, rowId: subGroup.id });
+          }
+        }
+      } else {
+        for (const task of group.tasks) {
+          gridItems.push({ ...task, columnId: group.id });
+        }
+      }
+    }
+
+    // Custom getItemsForCell to look up tasks by column/row
+    const getItemsForCell = (columnId: string, rowId?: string): GridItem[] => {
+      const group = groupedTasks.find((g) => g.id === columnId);
+      if (!group) return [];
+
+      if (rowId !== undefined && group.subGroups) {
+        const subGroup = group.subGroups.find((sg) => sg.id === rowId);
+        return (subGroup?.tasks || []).map((t) => ({ ...t, columnId, rowId }));
+      }
+      return group.tasks.map((t) => ({ ...t, columnId }));
+    };
+
+    // Calculate row totals for row headers
+    const getRowTotal = (rowId: string): number => {
+      return gridColumns.reduce(
+        (sum, col) => sum + getItemsForCell(col.id, rowId).length,
+        0,
+      );
+    };
+
+    // Handle drag end - update both column (primary grouping) and row (sub-grouping)
+    const handleGridDragEnd = async (
+      event: GridBoardDragEndEvent<GridItem>,
+    ) => {
+      const { item, toColumnId, toRowId } = event;
+      const itemId = item.id;
+
+      // Helper to update local state optimistically
+      const updateLocal = (updates: Partial<schema.TaskWithLabels>) => {
+        const updatedTasks = tasks.map((t) =>
+          t.id === itemId ? { ...t, ...updates } : t,
+        );
+        setTasks(updatedTasks);
+      };
+
+      // Helper to extract the actual value from prefixed IDs like "status:backlog" -> "backlog"
+      const extractValue = (id: string, prefix: string): string | null => {
+        if (id.startsWith(`${prefix}:`)) {
+          return id.slice(prefix.length + 1);
+        }
+        return null;
+      };
+
+      // Determine what fields to update based on grouping/subGrouping
+      const updates: Partial<schema.TaskWithLabels> = {};
+
+      // Handle column change (primary grouping)
+      if (grouping === "status") {
+        const status = extractValue(toColumnId, "status");
+        if (status) {
+          updates.status = status as schema.TaskWithLabels["status"];
+        }
+      } else if (grouping === "priority") {
+        const priority = extractValue(toColumnId, "priority");
+        if (priority) {
+          updates.priority = priority as schema.TaskWithLabels["priority"];
+        }
+      } else if (grouping === "assignee") {
+        const assigneeId = extractValue(toColumnId, "assignee");
+        if (assigneeId === "unassigned") {
+          updates.assignees = [];
+        } else if (assigneeId) {
+          const user = availableUsers.find((u) => u.id === assigneeId);
+          if (user) updates.assignees = [user];
+        }
+      } else if (grouping === "category") {
+        const categoryId = extractValue(toColumnId, "category");
+        if (categoryId === "none") {
+          updates.category = null;
+        } else if (categoryId) {
+          updates.category = categoryId;
+        }
+      }
+
+      // Handle row change (sub-grouping)
+      if (toRowId !== undefined) {
+        if (subGrouping === "status") {
+          const status = extractValue(toRowId, "status");
+          if (status) {
+            updates.status = status as schema.TaskWithLabels["status"];
+          }
+        } else if (subGrouping === "priority") {
+          const priority = extractValue(toRowId, "priority");
+          if (priority) {
+            updates.priority = priority as schema.TaskWithLabels["priority"];
+          }
+        } else if (subGrouping === "assignee") {
+          const assigneeId = extractValue(toRowId, "assignee");
+          if (assigneeId === "unassigned") {
+            updates.assignees = [];
+          } else if (assigneeId) {
+            const user = availableUsers.find((u) => u.id === assigneeId);
+            if (user) updates.assignees = [user];
+          }
+        } else if (subGrouping === "category") {
+          const categoryId = extractValue(toRowId, "category");
+          if (categoryId === "none") {
+            updates.category = null;
+          } else if (categoryId) {
+            updates.category = categoryId;
+          }
+        }
+      }
+
+      // Check if there are any updates to apply
+      if (Object.keys(updates).length === 0) {
+        // console.log("[GridBoard] No updates to apply", {
+        //   toColumnId,
+        //   toRowId,
+        //   grouping,
+        //   subGrouping,
+        // });
+        return;
+      }
+
+      // console.log("[GridBoard] Applying updates", {
+      //   itemId,
+      //   updates,
+      //   toColumnId,
+      //   toRowId,
+      // });
+
+      // Apply optimistic update
+      updateLocal(updates);
+
+      // Look up the task to pass to payload generators
+      const task = tasks.find((t) => t.id === itemId);
+      if (!task) return;
+
+      // Send updates to server via action system
+      if (updates.status) {
+        await dispatchPayload(getStatusUpdatePayload(task, updates.status));
+      }
+
+      if (updates.priority) {
+        await dispatchPayload(getPriorityUpdatePayload(task, updates.priority));
+      }
+
+      if (updates.assignees !== undefined) {
+        await dispatchPayload(
+          getAssigneeBulkUpdatePayload(
+            task,
+            updates.assignees.map((u) => u.id),
+            availableUsers,
+            sseClientId,
+          ),
+        );
+      }
+
+      if (updates.category !== undefined) {
+        await dispatchPayload(
+          getCategoryUpdatePayload(task, updates.category, categories),
+        );
+      }
+    };
+
+    // Render drag overlay
+    const renderDragOverlay = (item: GridItem) => {
+      const dragFieldPerms: FieldPermissions | undefined =
+        permissionsByOrg && accountId
+          ? getTaskFieldPermissions(
+              item,
+              accountId,
+              permissionsByOrg[item.organizationId],
+            )
+          : undefined;
+
+      return (
+        <div className="opacity-90 rotate-2 scale-105">
+          <UnifiedTaskItem
+            viewMode="kanban"
+            task={item}
+            columnId={item.columnId}
+            tasks={tasks}
+            setTasks={setTasks}
+            availableUsers={availableUsers}
+            availableLabels={availableLabels}
+            onTaskUpdate={handleTaskUpdate}
+            onAddRelation={handleAddRelation}
+            categories={categories}
+            releases={releases}
+            compact={compact}
+            personal={personal}
+            fieldPermissions={dragFieldPerms}
+            organization={organization}
+          />
+        </div>
+      );
+    };
+
+    return (
+      <GridBoardProvider
+        columns={gridColumns}
+        rows={gridRows}
+        items={gridItems}
+        getItemsForCell={getItemsForCell}
+        onDragEnd={handleGridDragEnd}
+        renderDragOverlay={renderDragOverlay}
+        mode={hasKanbanSubGroups ? "grid" : "kanban"}
+      >
+        {/* Column Headers */}
+        <GridBoardColumns>
+          {(column) => (
+            <GridBoardColumnHeader key={column.id} column={column} />
+          )}
+        </GridBoardColumns>
+
+        {/* Rows with cells (if sub-groups exist) */}
+        {hasKanbanSubGroups && gridRows ? (
+          <GridBoardRows>
+            {(row) => (
+              <div key={row.id}>
+                <GridBoardRowHeader row={row} count={getRowTotal(row.id)} />
+                <GridBoardCells rowId={row.id}>
+                  {(item: GridItem, column) => (
+                    <GridBoardItem key={item.id} item={item}>
+                      {renderTaskItem(item, column.id, "kanban", column.id)}
+                    </GridBoardItem>
+                  )}
+                </GridBoardCells>
+              </div>
+            )}
+          </GridBoardRows>
+        ) : (
+          /* No sub-groups: render cells directly (kanban mode) */
+          <GridBoardCells>
+            {(item: GridItem, column) => (
+              <GridBoardItem key={item.id} item={item}>
+                {renderTaskItem(item, column.id, "kanban", column.id)}
+              </GridBoardItem>
+            )}
+          </GridBoardCells>
+        )}
+      </GridBoardProvider>
+    );
+  };
+
+  const renderListSubGroup = (group: NestedTaskGroup, subGroup: TaskGroup) => {
+    const subGroupCollapsed = collapsedSections.has(
+      getSubGroupCollapseKey(group, subGroup),
+    );
+
+    return (
+      <div key={subGroup.id}>
+        {showGroupHeaders && (
+          <TaskGroupSectionHeader
+            group={subGroup}
+            isCollapsed={subGroupCollapsed}
+            onToggleCollapse={() =>
+              handleToggleSection(getSubGroupCollapseKey(group, subGroup))
+            }
+            isSubGroup={true}
+            className="py-1"
+            rootClassName="bg-muted/0 hover:bg-muted/20 transition-all"
+            compact={compact}
+          />
+        )}
+        {!subGroupCollapsed && (
+          <div className="py-1 flex flex-col gap-1">
+            {subGroup.tasks.length > 0
+              ? subGroup.tasks.map((task) =>
+                  renderTaskItem(task, group.id, "list"),
+                )
+              : renderEmptyGroup()}
+          </div>
+        )}
+      </div>
+    );
+  };
+
+  const renderListGroup = (group: NestedTaskGroup) => {
+    const isCollapsed = collapsedSections.has(group.id);
+    const hasSubGroups = group.subGroups && group.subGroups.length > 0;
+
+    const renderGroupContent = () => {
+      if (hasSubGroups && group.subGroups) {
+        return group.subGroups.map((subGroup) =>
+          renderListSubGroup(group, subGroup),
+        );
+      }
+      if (group.tasks.length > 0) {
+        return group.tasks.map((task) =>
+          renderTaskItem(task, group.id, "list"),
+        );
+      }
+      return renderEmptyGroup();
+    };
+
+    return (
+      <div key={group.id}>
+        {showGroupHeaders && (
+          <TaskGroupSectionHeader
+            group={group}
+            isCollapsed={isCollapsed}
+            onToggleCollapse={() => handleToggleSection(group.id)}
+            isSticky={true}
+            compact={compact}
+            rootClassName="bg-background"
+          />
+        )}
+        {!isCollapsed && (
+          <div className="flex flex-col gap-0">{renderGroupContent()}</div>
+        )}
+      </div>
+    );
+  };
+
+  const renderListView = () => {
+    if (groupedTasks.length === 0) {
+      return renderEmptyState();
+    }
+    return (
+      <div className={cn("rounded h-full", compact && "px-0")}>
+        {groupedTasks.map(renderListGroup)}
+      </div>
+    );
+  };
+
+  const renderMainContent = () => {
+    if (viewMode === "kanban") {
+      // Always use GridBoard for kanban - mode is set based on hasKanbanSubGroups
+      return renderKanbanView();
+    }
+    return renderListView();
+  };
+
+  // ============================================================================
+  // Main Return
+  // ============================================================================
+
+  if (!mounted) {
+    return renderLoading();
+  }
+  const smallViewport = window.innerWidth < 1000;
+  return (
+    <div className={cn("h-full overflow-auto rounded", classNameProp)}>
+      {renderMainContent()}
+      {!compact && (
+        <BulkActionBar
+          selectedCount={selectedCount}
+          selectedTasks={selectedTaskData}
+          visible={selectedCount > 0 && viewMode === "list"}
+          onDeselectAll={deselectAll}
+          onSelectAll={() => selectAll(visibleTaskIds)}
+          isAllSelected={isAllSelected}
+          isIndeterminate={isIndeterminate}
+          onBulkUpdate={handleBulkUpdate}
+          availableUsers={availableUsers}
+          availableLabels={availableLabels}
+          categories={categories}
+          releases={releases}
+          compact={smallViewport}
+        />
+      )}
+      <TaskDetailDialog
+        task={dialogTask}
+        open={dialogTask !== null}
+        onOpenChange={(open) => {
+          if (!open) setDialogTask(null);
+        }}
+        tasks={tasks}
+        setTasks={setTasks}
+        labels={availableLabels}
+        categories={categories}
+        releases={releases}
+        organization={organization}
+        fieldPermissions={
+          dialogTask && permissionsByOrg && accountId
+            ? getTaskFieldPermissions(
+                dialogTask,
+                accountId,
+                permissionsByOrg[dialogTask.organizationId],
+              )
+            : undefined
+        }
+      />
+    </div>
+  );
 }

--- a/apps/start/src/lib/fetches/ai.ts
+++ b/apps/start/src/lib/fetches/ai.ts
@@ -204,6 +204,17 @@ export interface RecommendedRelation {
 	shortId: number | null;
 }
 
+/**
+ * A suggested status change, derived from linked GitHub activity rather than
+ * the model — see `computeStatusSuggestion` in the backend route. `reason`
+ * is a ready-to-display timeline-style sentence (e.g. "Jane linked branch
+ * feature/foo" or "Linked PR #42 was merged").
+ */
+export interface RecommendedStatus {
+	value: "in-progress" | "done";
+	reason: string;
+}
+
 export interface RecommendationsResult {
 	labelIds: string[];
 	assigneeIds: string[];
@@ -211,6 +222,7 @@ export interface RecommendationsResult {
 	categoryId: string | null;
 	releaseId: string | null;
 	relations: RecommendedRelation[];
+	status: RecommendedStatus | null;
 	reasoning?: string;
 	/** Echoed back for the admin-only "View prompt" debug affordance — omitted when no AI call was made (e.g. every enabled kind had nothing to offer). */
 	systemPrompt?: string;

--- a/packages/ai-prompts/src/prompts/recommendations.ts
+++ b/packages/ai-prompts/src/prompts/recommendations.ts
@@ -14,6 +14,12 @@ import type { PromptConfig } from "../types.js";
  * response-format hint listing only the enabled kinds for each call, so the
  * system prompt below stays generic across every combination.
  *
+ * Status suggestions (`recommend-status`) are a separate, deterministic kind
+ * — moving backlog/todo to in-progress or todo/in-progress to done based on
+ * linked GitHub activity (a branch/PR link, a commit, a mention, a merged
+ * PR). That's computed directly from `taskTimeline`/`githubPullRequest` in
+ * the route, not asked of this model — see `computeStatusSuggestion` there.
+ *
  * Deliberately always uses a small, cheap model (see the route's hardcoded
  * `RECOMMENDATIONS_MODEL`) — this never generates or writes prose, just
  * picks from closed candidate lists, so it doesn't need a larger model's


### PR DESCRIPTION
## Release Notes

### New Features
- Added an AI recommendation for task status. When enabled in org AI settings, the recommendations panel can now suggest moving a task to "In Progress" or "Done" based on linked GitHub activity (a linked branch, commit, mention, or a merged pull request), with a hover tooltip explaining the specific signal behind the suggestion.

### Bug Fixes
- Fixed sub-group headers on the list view sharing collapse state across different parent groups (e.g. collapsing "Bug report" under one status group no longer collapses every other group's "Bug report" sub-group too), since sub-group ids aren't unique per parent group.
- Empty groups and sub-groups on the list view now auto-collapse by default.

### Improvements
- Sub-grouping headers on the list view (e.g. category/label groupings nested under a status) now have their own background so they're visually distinguishable from the parent group header instead of blending in.
- Increased the background contrast on priority group headers (urgent, high, low) so priority groupings stand out more clearly.
- Collapsed sections now also reset when the sub-grouping changes, not just the primary grouping.

## Summary
Addresses list-view rendering feedback: nested sub-group headers were hard to distinguish from their parent group and empty groups didn't auto-collapse, and toggling one sub-group's collapsed state could incorrectly affect same-named sub-groups under other parent groups. Also adds an opt-in AI recommendation that suggests updating a task's status based on linked GitHub activity.

## Technical Details
- `apps/start/src/components/tasks/views/unified-task-view.tsx`: introduced `getSubGroupCollapseKey(group, subGroup)` (`${group.id}::${subGroup.id}`) to scope sub-group collapse tracking per parent group, since sub-group ids are intentionally shared across parent groups (required for Kanban's row/column matrix). Collapse state now resets on both `grouping` and `subGrouping` changes via a `groupedTasksRef`, defaulting empty groups/sub-groups to collapsed.
- `apps/start/src/components/tasks/task/task-group-section-header.tsx`: adjusted header container classes (`rounded-xl`, `bg-card` on the inner row) so nested group headers read as distinct surfaces.
- `apps/start/src/components/tasks/shared/config.tsx`: adjusted `GROUP_HEADER_STYLES` background opacities for the priority grouping (urgent `/5`→`/10`, high `/5`→`/15`, low `bg-muted`→`bg-card/5`).
- `apps/backend/routes/api/internal/v1/ai/recommendations.ts`: added a deterministic, rule-based `computeStatusSuggestion` (not LLM-driven) that reads `taskTimeline`/linked PR data to suggest `in-progress` (backlog/todo tasks with GitHub branch/PR/commit/mention activity) or `done` (todo/in-progress tasks whose linked PR merged), gated by a new `recommend-status` org AI setting.
- `apps/start/src/components/tasks/task/task-ai-recommendations.tsx`: renders the new status suggestion as a chip with apply/dismiss actions and a tooltip carrying the underlying timeline signal.

## Related Sayr Tasks
- SAY-67: Missing styling on sub grouping on list view (https://platform.sayr.io/67)
- SAY-68: Recommended status (https://platform.sayr.io/68)