### PR TITLE
Two-way GitHub sync for public tasks (SAY-41)

### DIFF
--- a/apps/backend/lib/tasks/updateTask.ts
+++ b/apps/backend/lib/tasks/updateTask.ts
@@ -1,10 +1,17 @@
 import { Octokit } from "@octokit/rest";
-import { addLogEventTask, db, getOrganizationMembers, getTaskById, schema } from "@repo/database";
+import {
+	addLogEventTask,
+	db,
+	findSyncEligibleGithubRepo,
+	getOrganizationMembers,
+	getTaskById,
+	schema,
+} from "@repo/database";
 import { getEditionCapabilities } from "@repo/edition";
 import { createTraceAsync } from "@repo/opentelemetry/trace";
 import { enqueue } from "@repo/queue";
 import { getInstallationToken } from "@repo/util/github/auth";
-import { and, eq, isNull } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { emitEvent } from "@/clickhouse";
 import {
 	findClientBysseId,
@@ -40,10 +47,17 @@ export interface UpdateTaskServiceParams {
 	actorUserId: string;
 	/** Optional SSE client id to exclude from the broadcast (the caller's own already-applied client). `undefined` for API callers, so every connected client — including the caller's own future SSE connections — receives the broadcast. */
 	sseClientId?: string;
+	/**
+	 * When `true`, skip the outbound GitHub sync paths below (currently: the
+	 * status-close push). Set by inbound GitHub→Sayr updates (e.g. `handleIssueEdited`)
+	 * so that applying a change that originated on GitHub doesn't immediately
+	 * queue a redundant outbound push back to GitHub.
+	 */
+	skipGithubSync?: boolean;
 }
 
 export async function updateTaskService(params: UpdateTaskServiceParams) {
-	const { orgId, taskId, existingTask, updates, actorUserId, sseClientId } = params;
+	const { orgId, taskId, existingTask, updates, actorUserId, sseClientId, skipGithubSync } = params;
 	const traceAsync = createTraceAsync();
 	const userId = actorUserId;
 
@@ -87,7 +101,19 @@ export async function updateTaskService(params: UpdateTaskServiceParams) {
 					timelineEventId: event?.id,
 				});
 
-				if ((updates.status === "done" || updates.status === "in-progress") && existingTask?.githubIssue) {
+				if (
+					!skipGithubSync &&
+					(updates.status === "done" || updates.status === "in-progress") &&
+					existingTask?.githubIssue
+				) {
+					// A task that is (or is becoming) private is never synced to GitHub —
+					// same gate `/create` and the description/comment sync paths use.
+					const effectiveVisible =
+						(updates.visible as schema.taskType["visible"] | undefined) ?? existingTask.visible;
+					if (effectiveVisible === "private") {
+						return;
+					}
+
 					// Derive the issue number from your stored field.
 					// Adjust this if your schema is different.
 					const issueNumber = existingTask.githubIssue.issueNumber ?? existingTask.githubIssue;
@@ -97,13 +123,7 @@ export async function updateTaskService(params: UpdateTaskServiceParams) {
 						return;
 					}
 
-					const foundLink = await db.query.githubRepository.findFirst({
-						where: and(
-							eq(schema.githubRepository.organizationId, orgId),
-							isNull(schema.githubRepository.categoryId),
-							eq(schema.githubRepository.enabled, true)
-						),
-					});
+					const foundLink = await findSyncEligibleGithubRepo(orgId, existingTask.category);
 
 					// No linked repo? Just skip GitHub logic, but don't break the request.
 					if (!foundLink) {

--- a/apps/backend/prosekit/resolveMentions.ts
+++ b/apps/backend/prosekit/resolveMentions.ts
@@ -1,0 +1,51 @@
+import { db, schema } from "@repo/database";
+import { formatTaskKey } from "@repo/util";
+import { and, eq } from "drizzle-orm";
+
+/**
+ * Before serializing a description/comment to markdown for a GitHub push,
+ * rewrites every `kind: "task"` mention's fallback `value` into a real
+ * markdown link to the task's public URL. `prosekitJSONToMarkdown`'s
+ * `mention` handler just writes `value` verbatim, so without this every
+ * task mention shows up on GitHub as plain, unlinked text.
+ *
+ * Leaves `value` untouched when the mentioned task can't be resolved, or is
+ * private — this content is headed to a public GitHub issue, so a private
+ * task's existence/title must never leak into it via a link.
+ */
+export async function resolveMentionLinksForGithub(doc: schema.NodeJSON, orgId: string): Promise<schema.NodeJSON> {
+	const org = await db.query.organization.findFirst({
+		where: eq(schema.organization.id, orgId),
+		columns: { shortId: true, slug: true },
+	});
+	if (!org) return doc;
+	// Rebind so the nested closure below narrows correctly — TS doesn't
+	// carry the `!org` guard's narrowing across a function boundary.
+	const resolvedOrg = org;
+
+	async function walk(node: unknown): Promise<unknown> {
+		if (!node || typeof node !== "object") return node;
+		const n = node as { type?: string; attrs?: Record<string, unknown>; content?: unknown[] };
+
+		if (n.type === "mention" && n.attrs?.kind === "task" && n.attrs?.id) {
+			const task = await db.query.task.findFirst({
+				where: and(eq(schema.task.id, n.attrs.id as string), eq(schema.task.organizationId, orgId)),
+				columns: { shortId: true, visible: true },
+			});
+			if (task?.visible === "public") {
+				const url = `https://${resolvedOrg.slug}.${process.env.VITE_ROOT_DOMAIN}/${task.shortId}`;
+				const key = formatTaskKey(resolvedOrg.shortId, task.shortId);
+				return { ...n, attrs: { ...n.attrs, value: `[${key}](${url})` } };
+			}
+			return n;
+		}
+
+		if (Array.isArray(n.content)) {
+			return { ...n, content: await Promise.all(n.content.map(walk)) };
+		}
+
+		return n;
+	}
+
+	return (await walk(doc)) as schema.NodeJSON;
+}

--- a/apps/backend/routes/api/internal/v1/task.ts
+++ b/apps/backend/routes/api/internal/v1/task.ts
@@ -38,6 +38,7 @@ import { Hono } from "hono";
 import { emitEvent, type PlatformEventType } from "@/clickhouse";
 import type { AppEnv } from "@/index";
 import { prosekitJSONToMarkdown } from "@/prosekit/markdown";
+import { resolveMentionLinksForGithub } from "@/prosekit/resolveMentions";
 import {
 	findClientBysseId,
 	findSSEClientsByUserId,
@@ -290,7 +291,10 @@ apiRouteAdminProjectTask.post("/create", async (c) => {
 			const owner = repoInfo.owner.login;
 			const repo = repoInfo.name;
 
-			const description = taskWithData.description ? prosekitJSONToMarkdown(taskWithData.description) : "";
+			const resolvedDescription = taskWithData.description
+				? await resolveMentionLinksForGithub(taskWithData.description, orgId)
+				: null;
+			const description = resolvedDescription ? prosekitJSONToMarkdown(resolvedDescription) : "";
 			const body =
 				`↪ From Sayr task ${sayrTaskUrl}\n\n` +
 				`${SAYR_TASK_LINK_MARKER_PREFIX}${taskWithData.id} -->\n\n` +
@@ -1681,7 +1685,8 @@ apiRouteAdminProjectTask.post("/create-comment", async (c) => {
 						const owner = repoInfo.owner.login;
 						const repo = repoInfo.name;
 						const effectiveCreatedBy = source === "github" ? bodyCreatedBy : (bodyCreatedBy ?? session?.userId);
-						const markdown = prosekitJSONToMarkdown(content);
+						const resolvedContent = await resolveMentionLinksForGithub(content, orgId);
+						const markdown = prosekitJSONToMarkdown(resolvedContent);
 
 						// Prefer posting as the actual author via their own linked GitHub
 						// token — shows up as a genuine comment from them, no bot involved.
@@ -1928,7 +1933,8 @@ apiRouteAdminProjectTask.put("/edit-comment", async (c) => {
 					if (!repoInfo.private) {
 						const owner = repoInfo.owner.login;
 						const repo = repoInfo.name;
-						const markdown = prosekitJSONToMarkdown(content);
+						const resolvedContent = await resolveMentionLinksForGithub(content, orgId);
+						const markdown = prosekitJSONToMarkdown(resolvedContent);
 
 						const userToken = await getUserGithubToken(comment.createdBy);
 						const postingOctokit = userToken ? new Octokit({ auth: userToken }) : octokit;

--- a/apps/backend/routes/api/internal/v1/task.ts
+++ b/apps/backend/routes/api/internal/v1/task.ts
@@ -52,6 +52,7 @@ import {
 	getClientIP,
 	refreshGitHubTokenIfNeeded,
 	SAYR_COMMENT_SYNC_MARKER,
+	SAYR_TASK_LINK_MARKER_PREFIX,
 	traceOrgPermissionCheck,
 	tracePublicOrgAccessCheck,
 } from "@/util";
@@ -87,11 +88,15 @@ apiRouteAdminProjectTask.post("/create", async (c) => {
 		category,
 		releaseId,
 		parentId,
+		skipGithubSync,
+		createdBy: bodyCreatedBy,
 	} = body;
 	let { visible } = body as {
 		visible?: "public" | "private";
 	};
 	const session = c.get("session");
+	const user = c.get("user");
+	const isSystemAccount = user?.role === "system";
 
 	const isAuthorized = await traceOrgPermissionCheck(session?.userId || "", orgId, "tasks.create");
 
@@ -107,13 +112,18 @@ apiRouteAdminProjectTask.post("/create", async (c) => {
 		// If public is allowed, respect request (default to private if undefined)
 		visible = visible === "public" ? "public" : "private";
 	}
+	// Only the internal system account may attribute a task to someone other
+	// than the requesting session — used when the GitHub sync worker creates a
+	// task for an issue opened by a Sayr-linked GitHub user, so the task shows
+	// them as the creator instead of the system account.
+	const effectiveCreatedBy = isSystemAccount && bodyCreatedBy ? bodyCreatedBy : session?.userId;
 	const task = await traceAsync(
 		"task.create.insert",
 		() =>
 			createTask(
 				orgId,
 				{ title, description, status, priority, category, releaseId, visible, parentId },
-				session?.userId
+				effectiveCreatedBy
 			),
 		{
 			description: "Creating task record",
@@ -156,7 +166,7 @@ apiRouteAdminProjectTask.post("/create", async (c) => {
 				"created",
 				null,
 				{ status, priority, title, labels, assignees },
-				session?.userId,
+				effectiveCreatedBy,
 				description
 			);
 		},
@@ -233,6 +243,12 @@ apiRouteAdminProjectTask.post("/create", async (c) => {
 	await traceAsync(
 		"task.create.github_sync",
 		async () => {
+			// Set when this task was itself created FROM a GitHub issue (see the
+			// worker's `issue_opened` handler) — without this, creating the task
+			// would immediately try to create a second, duplicate GitHub issue
+			// for it.
+			if (skipGithubSync) return;
+
 			let foundLink = null;
 
 			// 1️⃣ Try exact category match (if category provided)
@@ -277,7 +293,7 @@ apiRouteAdminProjectTask.post("/create", async (c) => {
 			const description = taskWithData.description ? prosekitJSONToMarkdown(taskWithData.description) : "";
 			const body =
 				`↪ From Sayr task ${sayrTaskUrl}\n\n` +
-				`<!-- sayr-task:${taskWithData.id} -->\n\n` +
+				`${SAYR_TASK_LINK_MARKER_PREFIX}${taskWithData.id} -->\n\n` +
 				`---\n\n` +
 				description;
 			const { data: issue } = await octokit.request("POST /repos/{owner}/{repo}/issues", {

--- a/apps/backend/routes/api/internal/v1/task.ts
+++ b/apps/backend/routes/api/internal/v1/task.ts
@@ -11,6 +11,7 @@ import {
 	db,
 	extractTaskMentions,
 	extractUserMentions,
+	findSyncEligibleGithubRepo,
 	getBlockedUserIds,
 	getCommentReplies,
 	getCommentReplyCountBatch,
@@ -36,6 +37,7 @@ import { and, desc, eq, ilike, isNull, notInArray, or, sql } from "drizzle-orm";
 import { Hono } from "hono";
 import { emitEvent, type PlatformEventType } from "@/clickhouse";
 import type { AppEnv } from "@/index";
+import { prosekitJSONToMarkdown } from "@/prosekit/markdown";
 import {
 	findClientBysseId,
 	findSSEClientsByUserId,
@@ -265,7 +267,12 @@ apiRouteAdminProjectTask.post("/create", async (c) => {
 			const owner = repoInfo.owner.login;
 			const repo = repoInfo.name;
 
-			const body = `↪ From Sayr task ${sayrTaskUrl}\n\n` + `<!-- sayr-task:${taskWithData.id} -->\n\n` + `---\n\n`;
+			const description = taskWithData.description ? prosekitJSONToMarkdown(taskWithData.description) : "";
+			const body =
+				`↪ From Sayr task ${sayrTaskUrl}\n\n` +
+				`<!-- sayr-task:${taskWithData.id} -->\n\n` +
+				`---\n\n` +
+				description;
 			const { data: issue } = await octokit.request("POST /repos/{owner}/{repo}/issues", {
 				owner,
 				repo,
@@ -517,7 +524,7 @@ apiRouteAdminProjectTask.patch("/update", async (c) => {
 	const traceAsync = createTraceAsync();
 	const recordWideError = c.get("recordWideError");
 
-	const { org_id: orgId, sseClientId, task_id: taskId, ...updates } = await c.req.json();
+	const { org_id: orgId, sseClientId, task_id: taskId, skipGithubSync, ...updates } = await c.req.json();
 	const session = c.get("session");
 	const user = c.get("user");
 	const isSystemAccount = user?.role === "system";
@@ -599,6 +606,7 @@ apiRouteAdminProjectTask.patch("/update", async (c) => {
 		updates,
 		actorUserId: userId,
 		sseClientId,
+		skipGithubSync: skipGithubSync === true,
 	});
 
 	return c.json({ success: true, data: taskWithData });
@@ -1446,6 +1454,7 @@ apiRouteAdminProjectTask.post("/update-assignees", async (c) => {
 // Create a comment on a task
 apiRouteAdminProjectTask.post("/create-comment", async (c) => {
 	const traceAsync = createTraceAsync();
+	const recordWideError = c.get("recordWideError");
 
 	const {
 		org_id: orgId,
@@ -1552,7 +1561,7 @@ apiRouteAdminProjectTask.post("/create-comment", async (c) => {
 		resolvedVisibility = parentComment.visibility;
 	}
 
-	await traceAsync(
+	const newComment = await traceAsync(
 		"task.comment.create.insert",
 		() => {
 			// For GitHub-sourced comments, only set createdBy if explicitly provided (linked Sayr user).
@@ -1582,6 +1591,62 @@ apiRouteAdminProjectTask.post("/create-comment", async (c) => {
 			}),
 		}
 	);
+
+	// Outbound sync: a new public, Sayr-authored comment on a task linked to a
+	// public GitHub issue gets mirrored to GitHub too. Never fatal — a
+	// GitHub-side failure must never break comment creation on Sayr.
+	if ((source === "sayr" || !source) && resolvedVisibility === "public" && newComment) {
+		try {
+			const syncTask = await db.query.task.findFirst({
+				where: (t) => and(eq(t.id, taskId), eq(t.organizationId, orgId)),
+				with: { githubIssue: true },
+			});
+
+			if (syncTask?.visible === "public" && syncTask.githubIssue) {
+				const repoLink = await findSyncEligibleGithubRepo(orgId, syncTask.category);
+
+				if (repoLink) {
+					const token = await getInstallationToken(repoLink.installationId);
+					const octokit = new Octokit({ auth: token });
+
+					const { data: repoInfo } = await octokit.request("GET /repositories/{repository_id}", {
+						repository_id: repoLink.repoId,
+					});
+
+					if (!repoInfo.private) {
+						const owner = repoInfo.owner.login;
+						const repo = repoInfo.name;
+
+						const { data: ghComment } = await octokit.request(
+							"POST /repos/{owner}/{repo}/issues/{issue_number}/comments",
+							{
+								owner,
+								repo,
+								issue_number: syncTask.githubIssue.issueNumber,
+								body: prosekitJSONToMarkdown(content),
+							}
+						);
+
+						await db
+							.update(schema.taskComment)
+							.set({
+								externalCommentId: ghComment.id,
+								externalCommentUrl: ghComment.html_url,
+							})
+							.where(eq(schema.taskComment.id, newComment.id));
+					}
+				}
+			}
+		} catch (err) {
+			await recordWideError({
+				name: "task.comment.create.github_sync.failed",
+				error: err,
+				code: "GITHUB_COMMENT_SYNC_FAILED",
+				message: "Failed to sync new comment to GitHub",
+				contextData: { orgId, taskId, commentId: newComment.id },
+			});
+		}
+	}
 
 	// Notify assignees and mentioned users about the new comment.
 	// Users who are both assigned AND mentioned only receive one notification (the "comment" type).
@@ -1761,6 +1826,53 @@ apiRouteAdminProjectTask.put("/edit-comment", async (c) => {
 		}
 	);
 
+	// Outbound sync: push the new content to the mirrored GitHub comment, if
+	// this Sayr-authored comment was previously pushed there and is (still,
+	// or now) public. Never fatal — a GitHub-side failure must never break
+	// editing the comment on Sayr.
+	const effectiveVisibility = visibility ?? comment.visibility;
+	if (comment.source === "sayr" && comment.externalCommentId && effectiveVisibility === "public" && comment.taskId) {
+		try {
+			const syncTask = await db.query.task.findFirst({
+				where: (t) => and(eq(t.id, comment.taskId as string), eq(t.organizationId, orgId)),
+				with: { githubIssue: true },
+			});
+
+			if (syncTask?.visible === "public" && syncTask.githubIssue) {
+				const repoLink = await findSyncEligibleGithubRepo(orgId, syncTask.category);
+
+				if (repoLink) {
+					const token = await getInstallationToken(repoLink.installationId);
+					const octokit = new Octokit({ auth: token });
+
+					const { data: repoInfo } = await octokit.request("GET /repositories/{repository_id}", {
+						repository_id: repoLink.repoId,
+					});
+
+					if (!repoInfo.private) {
+						const owner = repoInfo.owner.login;
+						const repo = repoInfo.name;
+
+						await octokit.request("PATCH /repos/{owner}/{repo}/issues/comments/{comment_id}", {
+							owner,
+							repo,
+							comment_id: comment.externalCommentId,
+							body: prosekitJSONToMarkdown(content),
+						});
+					}
+				}
+			}
+		} catch (err) {
+			await recordWideError({
+				name: "task.comment.edit.github_sync.failed",
+				error: err,
+				code: "GITHUB_COMMENT_SYNC_FAILED",
+				message: "Failed to sync edited comment to GitHub",
+				contextData: { orgId, commentId, externalCommentId: comment.externalCommentId },
+			});
+		}
+	}
+
 	await traceAsync(
 		"task.comment.edit.broadcast",
 		async () => {
@@ -1850,6 +1962,49 @@ apiRouteAdminProjectTask.delete("/delete-comment", async (c) => {
 
 		if (!task) {
 			return c.json({ success: false, error: "Task not found or is not public." }, 404);
+		}
+	}
+
+	// Outbound sync: delete the mirrored GitHub comment too, if this comment
+	// was previously pushed to (or pulled from) GitHub. Never fatal — a
+	// GitHub-side failure must never block deleting the comment on Sayr.
+	if (comment.source === "sayr" && comment.externalCommentId) {
+		try {
+			const syncTask = comment.taskId
+				? await db.query.task.findFirst({
+						where: (t) => and(eq(t.id, comment.taskId as string), eq(t.organizationId, orgId)),
+						with: { githubIssue: true },
+					})
+				: null;
+
+			if (syncTask?.visible === "public" && syncTask.githubIssue) {
+				const repoLink = await findSyncEligibleGithubRepo(orgId, syncTask.category);
+
+				if (repoLink) {
+					const token = await getInstallationToken(repoLink.installationId);
+					const octokit = new Octokit({ auth: token });
+
+					const { data: repoInfo } = await octokit.request("GET /repositories/{repository_id}", {
+						repository_id: repoLink.repoId,
+					});
+
+					if (!repoInfo.private) {
+						await octokit.request("DELETE /repos/{owner}/{repo}/issues/comments/{comment_id}", {
+							owner: repoInfo.owner.login,
+							repo: repoInfo.name,
+							comment_id: comment.externalCommentId,
+						});
+					}
+				}
+			}
+		} catch (err) {
+			await recordWideError({
+				name: "task.comment.delete.github_sync.failed",
+				error: err,
+				code: "GITHUB_COMMENT_SYNC_FAILED",
+				message: "Failed to sync comment deletion to GitHub",
+				contextData: { orgId, commentId, externalCommentId: comment.externalCommentId },
+			});
 		}
 	}
 
@@ -1952,6 +2107,54 @@ apiRouteAdminProjectTask.patch("/update-comment-visibility", async (c) => {
 		return c.json({ success: false, error: "You don't have permission to change this comment's visibility." }, 403);
 	}
 
+	// Outbound sync: flipping a previously-synced public comment to internal
+	// deletes its mirrored GitHub copy (per decision — internal comments are
+	// never visible on GitHub). Never fatal — a GitHub-side failure must
+	// never block the visibility change on Sayr.
+	const externalCommentId = comment.externalCommentId;
+	const isFlippingToInternal =
+		comment.source === "sayr" && comment.visibility === "public" && visibility === "internal" && !!externalCommentId;
+
+	if (isFlippingToInternal && externalCommentId) {
+		try {
+			const syncTask = comment.taskId
+				? await db.query.task.findFirst({
+						where: (t) => and(eq(t.id, comment.taskId as string), eq(t.organizationId, orgId)),
+						with: { githubIssue: true },
+					})
+				: null;
+
+			if (syncTask?.visible === "public" && syncTask.githubIssue) {
+				const repoLink = await findSyncEligibleGithubRepo(orgId, syncTask.category);
+
+				if (repoLink) {
+					const token = await getInstallationToken(repoLink.installationId);
+					const octokit = new Octokit({ auth: token });
+
+					const { data: repoInfo } = await octokit.request("GET /repositories/{repository_id}", {
+						repository_id: repoLink.repoId,
+					});
+
+					if (!repoInfo.private) {
+						await octokit.request("DELETE /repos/{owner}/{repo}/issues/comments/{comment_id}", {
+							owner: repoInfo.owner.login,
+							repo: repoInfo.name,
+							comment_id: externalCommentId,
+						});
+					}
+				}
+			}
+		} catch (err) {
+			await recordWideError({
+				name: "task.comment.visibility.github_sync.failed",
+				error: err,
+				code: "GITHUB_COMMENT_SYNC_FAILED",
+				message: "Failed to sync comment visibility flip to GitHub",
+				contextData: { orgId, commentId, externalCommentId },
+			});
+		}
+	}
+
 	// Update the comment visibility
 	await traceAsync(
 		"task.comment.visibility.update",
@@ -1961,6 +2164,13 @@ apiRouteAdminProjectTask.patch("/update-comment-visibility", async (c) => {
 				.set({
 					visibility,
 					updatedAt: new Date(),
+					// Clear the external linkage so a later flip back to public
+					// creates a fresh GitHub comment rather than trying to
+					// resurrect the one just deleted above.
+					...(isFlippingToInternal && {
+						externalCommentId: null,
+						externalCommentUrl: null,
+					}),
 				})
 				.where(eq(schema.taskComment.id, commentId)),
 		{

--- a/apps/backend/routes/api/internal/v1/task.ts
+++ b/apps/backend/routes/api/internal/v1/task.ts
@@ -1451,6 +1451,23 @@ apiRouteAdminProjectTask.post("/update-assignees", async (c) => {
 	}
 });
 
+// Prefixes an outbound (Sayr → GitHub) comment body with who actually wrote
+// it on Sayr. The GitHub App can only ever post as its own bot identity
+// (there's no way to post "as" the real GitHub-linked user via an
+// installation token), so without this every synced comment shows up on
+// GitHub as an anonymous-looking bot post with no indication of the author.
+async function buildSyncedCommentBody(authorId: string | null | undefined, markdown: string): Promise<string> {
+	let authorLabel = "A Sayr user";
+	if (authorId) {
+		const author = await db.query.user.findFirst({
+			where: (t) => eq(t.id, authorId),
+			columns: { displayName: true, name: true },
+		});
+		if (author) authorLabel = author.displayName || author.name || authorLabel;
+	}
+	return `**${authorLabel}** commented via Sayr:\n\n${markdown}`;
+}
+
 // Create a comment on a task
 apiRouteAdminProjectTask.post("/create-comment", async (c) => {
 	const traceAsync = createTraceAsync();
@@ -1616,6 +1633,7 @@ apiRouteAdminProjectTask.post("/create-comment", async (c) => {
 					if (!repoInfo.private) {
 						const owner = repoInfo.owner.login;
 						const repo = repoInfo.name;
+						const effectiveCreatedBy = source === "github" ? bodyCreatedBy : (bodyCreatedBy ?? session?.userId);
 
 						const { data: ghComment } = await octokit.request(
 							"POST /repos/{owner}/{repo}/issues/{issue_number}/comments",
@@ -1623,7 +1641,7 @@ apiRouteAdminProjectTask.post("/create-comment", async (c) => {
 								owner,
 								repo,
 								issue_number: syncTask.githubIssue.issueNumber,
-								body: prosekitJSONToMarkdown(content),
+								body: await buildSyncedCommentBody(effectiveCreatedBy, prosekitJSONToMarkdown(content)),
 							}
 						);
 
@@ -1857,7 +1875,7 @@ apiRouteAdminProjectTask.put("/edit-comment", async (c) => {
 							owner,
 							repo,
 							comment_id: comment.externalCommentId,
-							body: prosekitJSONToMarkdown(content),
+							body: await buildSyncedCommentBody(comment.createdBy, prosekitJSONToMarkdown(content)),
 						});
 					}
 				}

--- a/apps/backend/routes/api/internal/v1/task.ts
+++ b/apps/backend/routes/api/internal/v1/task.ts
@@ -47,7 +47,14 @@ import {
 	sseBroadcastToRoom,
 } from "@/routes/events";
 import type { ServerEventBaseMessage } from "@/routes/events/types";
-import { getAnonHash, getClientIP, traceOrgPermissionCheck, tracePublicOrgAccessCheck } from "@/util";
+import {
+	getAnonHash,
+	getClientIP,
+	refreshGitHubTokenIfNeeded,
+	SAYR_COMMENT_SYNC_MARKER,
+	traceOrgPermissionCheck,
+	tracePublicOrgAccessCheck,
+} from "@/util";
 import { notifyAssignees } from "../../../../lib/tasks/notify";
 import { updateTaskService } from "../../../../lib/tasks/updateTask";
 import {
@@ -1451,11 +1458,11 @@ apiRouteAdminProjectTask.post("/update-assignees", async (c) => {
 	}
 });
 
-// Prefixes an outbound (Sayr → GitHub) comment body with who actually wrote
-// it on Sayr. The GitHub App can only ever post as its own bot identity
-// (there's no way to post "as" the real GitHub-linked user via an
-// installation token), so without this every synced comment shows up on
-// GitHub as an anonymous-looking bot post with no indication of the author.
+// Fallback for outbound (Sayr → GitHub) comments whose author has no linked
+// GitHub account (or whose linked token can't be used — see
+// getUserGithubToken below): prefixes the body with who actually wrote it on
+// Sayr, since a bot-posted comment otherwise shows up on GitHub with no
+// indication of the real author.
 async function buildSyncedCommentBody(authorId: string | null | undefined, markdown: string): Promise<string> {
 	let authorLabel = "A Sayr user";
 	if (authorId) {
@@ -1465,7 +1472,31 @@ async function buildSyncedCommentBody(authorId: string | null | undefined, markd
 		});
 		if (author) authorLabel = author.displayName || author.name || authorLabel;
 	}
-	return `**${authorLabel}** commented via Sayr:\n\n${markdown}`;
+	return `**${authorLabel}** commented via Sayr:\n\n${markdown}\n\n${SAYR_COMMENT_SYNC_MARKER}`;
+}
+
+// Attempts to get a valid GitHub user-to-server access token for the given
+// Sayr user, so an outbound comment can be posted as literally them instead
+// of the App's bot identity. Returns null (caller falls back to the bot) if
+// the user has no linked GitHub account, or the token can't be obtained —
+// e.g. they revoked Sayr's GitHub authorization, or their linked account
+// simply doesn't have access to this particular repo (GitHub App user
+// tokens are scoped to the intersection of the App's configured permissions
+// and what the user themselves can do). Reuses the same refresh helper the
+// `/organization` installation routes already rely on for this exact thing.
+async function getUserGithubToken(authorId: string | null | undefined): Promise<string | null> {
+	if (!authorId) return null;
+	try {
+		const account = await db.query.account.findFirst({
+			where: (a) => and(eq(a.userId, authorId), eq(a.providerId, "github")),
+		});
+		if (!account?.accessToken) return null;
+
+		const refreshed = await refreshGitHubTokenIfNeeded(account);
+		return refreshed.accessToken ?? null;
+	} catch {
+		return null;
+	}
 }
 
 // Create a comment on a task
@@ -1634,14 +1665,25 @@ apiRouteAdminProjectTask.post("/create-comment", async (c) => {
 						const owner = repoInfo.owner.login;
 						const repo = repoInfo.name;
 						const effectiveCreatedBy = source === "github" ? bodyCreatedBy : (bodyCreatedBy ?? session?.userId);
+						const markdown = prosekitJSONToMarkdown(content);
 
-						const { data: ghComment } = await octokit.request(
+						// Prefer posting as the actual author via their own linked GitHub
+						// token — shows up as a genuine comment from them, no bot involved.
+						// Falls back to the App's bot identity (with a text attribution
+						// line) when they have no linked account, or the token's unusable.
+						const userToken = await getUserGithubToken(effectiveCreatedBy);
+						const postingOctokit = userToken ? new Octokit({ auth: userToken }) : octokit;
+						const body = userToken
+							? `${markdown}\n\n${SAYR_COMMENT_SYNC_MARKER}`
+							: await buildSyncedCommentBody(effectiveCreatedBy, markdown);
+
+						const { data: ghComment } = await postingOctokit.request(
 							"POST /repos/{owner}/{repo}/issues/{issue_number}/comments",
 							{
 								owner,
 								repo,
 								issue_number: syncTask.githubIssue.issueNumber,
-								body: await buildSyncedCommentBody(effectiveCreatedBy, prosekitJSONToMarkdown(content)),
+								body,
 							}
 						);
 
@@ -1870,12 +1912,19 @@ apiRouteAdminProjectTask.put("/edit-comment", async (c) => {
 					if (!repoInfo.private) {
 						const owner = repoInfo.owner.login;
 						const repo = repoInfo.name;
+						const markdown = prosekitJSONToMarkdown(content);
 
-						await octokit.request("PATCH /repos/{owner}/{repo}/issues/comments/{comment_id}", {
+						const userToken = await getUserGithubToken(comment.createdBy);
+						const postingOctokit = userToken ? new Octokit({ auth: userToken }) : octokit;
+						const body = userToken
+							? `${markdown}\n\n${SAYR_COMMENT_SYNC_MARKER}`
+							: await buildSyncedCommentBody(comment.createdBy, markdown);
+
+						await postingOctokit.request("PATCH /repos/{owner}/{repo}/issues/comments/{comment_id}", {
 							owner,
 							repo,
 							comment_id: comment.externalCommentId,
-							body: await buildSyncedCommentBody(comment.createdBy, prosekitJSONToMarkdown(content)),
+							body,
 						});
 					}
 				}

--- a/apps/backend/routes/webhook/github.ts
+++ b/apps/backend/routes/webhook/github.ts
@@ -5,6 +5,7 @@ import { enqueue } from "@repo/queue";
 import { verifySignature } from "@repo/util/github/verify";
 import { and, eq, or } from "drizzle-orm";
 import { Hono } from "hono";
+import { SAYR_COMMENT_SYNC_MARKER } from "@/util";
 
 const app = new Hono<AppEnv>();
 app.post("/", async (c) => {
@@ -297,6 +298,10 @@ async function handleContentEvents(
 
 				if (!body) return;
 				if (commenter.endsWith("[bot]")) return;
+				// A comment Sayr just pushed via a linked user's own GitHub token has a
+				// real (non-bot) `user.login`, so the check above alone won't catch it —
+				// the marker does. See SAYR_COMMENT_SYNC_MARKER for why.
+				if (body.includes(SAYR_COMMENT_SYNC_MARKER)) return;
 
 				const keywordMatches = extractSayrKeywords(body);
 
@@ -352,6 +357,7 @@ async function handleContentEvents(
 				// double-closing/relinking tasks from the same keyword.
 				const commenter = payload.comment?.user?.login ?? "unknown";
 				if (commenter.endsWith("[bot]")) return;
+				if (payload.comment?.body?.includes(SAYR_COMMENT_SYNC_MARKER)) return;
 
 				await enqueue("github", {
 					type: "issue_comment_edited",

--- a/apps/backend/routes/webhook/github.ts
+++ b/apps/backend/routes/webhook/github.ts
@@ -8,595 +8,644 @@ import { Hono } from "hono";
 
 const app = new Hono<AppEnv>();
 app.post("/", async (c) => {
-  const traceAsync = createTraceAsync();
-  const recordWideError = c.get("recordWideError");
+	const traceAsync = createTraceAsync();
+	const recordWideError = c.get("recordWideError");
 
-  const signature = c.req.header("x-hub-signature-256");
-  const event = c.req.header("x-github-event");
-  const rawBody = await c.req.text();
+	const signature = c.req.header("x-hub-signature-256");
+	const event = c.req.header("x-github-event");
+	const rawBody = await c.req.text();
 
-  if (!verifySignature(signature ?? null, rawBody)) {
-    await recordWideError({
-      name: "webhook.github.signature",
-      error: new Error("Invalid signature"),
-      code: "INVALID_SIGNATURE",
-      message: "GitHub webhook signature verification failed",
-      contextData: { event },
-    });
-    return c.text("❌ invalid signature", 401);
-  }
+	if (!verifySignature(signature ?? null, rawBody)) {
+		await recordWideError({
+			name: "webhook.github.signature",
+			error: new Error("Invalid signature"),
+			code: "INVALID_SIGNATURE",
+			message: "GitHub webhook signature verification failed",
+			contextData: { event },
+		});
+		return c.text("❌ invalid signature", 401);
+	}
 
-  const payload = JSON.parse(rawBody);
+	const payload = JSON.parse(rawBody);
 
-  switch (event) {
-    case "installation":
-      return handleInstallationEvent(payload, traceAsync);
+	switch (event) {
+		case "installation":
+			return handleInstallationEvent(payload, traceAsync);
 
-    case "create":
-    case "delete":
-    case "issues":
-    case "issue_comment":
-    case "pull_request":
-    case "push":
-      await handleContentEvents(event, payload, traceAsync);
-      break;
+		case "create":
+		case "delete":
+		case "issues":
+		case "issue_comment":
+		case "pull_request":
+		case "push":
+			await handleContentEvents(event, payload, traceAsync);
+			break;
 
-    default:
-      break;
-  }
+		default:
+			break;
+	}
 
-  return c.text(`Event handled: ${event}`, 200);
+	return c.text(`Event handled: ${event}`, 200);
 });
 export const GithubWebhookHandler = app;
 
 async function handleInstallationEvent(
-  payload: { action: string; installation: { id: number } },
-  traceAsync: ReturnType<typeof createTraceAsync>,
+	payload: { action: string; installation: { id: number } },
+	traceAsync: ReturnType<typeof createTraceAsync>
 ) {
-  const installationId = payload.installation.id;
+	const installationId = payload.installation.id;
 
-  if (payload.action === "created") {
-    await traceAsync(
-      "webhook.github.installation.create",
-      () =>
-        db.insert(schema.githubInstallation).values({
-          id: crypto.randomUUID(),
-          installationId,
-        }),
-      {
-        description: "Creating GitHub installation record",
-        data: { installationId },
-        onSuccess: () => ({
-          outcome: "Installation record created",
-          data: { installationId },
-        }),
-      },
-    );
+	if (payload.action === "created") {
+		await traceAsync(
+			"webhook.github.installation.create",
+			() =>
+				db.insert(schema.githubInstallation).values({
+					id: crypto.randomUUID(),
+					installationId,
+				}),
+			{
+				description: "Creating GitHub installation record",
+				data: { installationId },
+				onSuccess: () => ({
+					outcome: "Installation record created",
+					data: { installationId },
+				}),
+			}
+		);
 
-    return new Response("Installation registered ✅");
-  }
+		return new Response("Installation registered ✅");
+	}
 
-  if (payload.action === "deleted") {
-    await traceAsync(
-      "webhook.github.installation.delete",
-      () =>
-        db
-          .delete(schema.githubInstallation)
-          .where(eq(schema.githubInstallation.installationId, installationId)),
-      {
-        description: "Deleting GitHub installation record",
-        data: { installationId },
-        onSuccess: () => ({
-          outcome: "Installation record deleted",
-          data: { installationId },
-        }),
-      },
-    );
+	if (payload.action === "deleted") {
+		await traceAsync(
+			"webhook.github.installation.delete",
+			() => db.delete(schema.githubInstallation).where(eq(schema.githubInstallation.installationId, installationId)),
+			{
+				description: "Deleting GitHub installation record",
+				data: { installationId },
+				onSuccess: () => ({
+					outcome: "Installation record deleted",
+					data: { installationId },
+				}),
+			}
+		);
 
-    return new Response("Installation deleted ✅");
-  }
+		return new Response("Installation deleted ✅");
+	}
 
-  return new Response("✅ Job(s) received");
+	return new Response("✅ Job(s) received");
 }
 
 async function handleContentEvents(
-  event: string,
-  // biome-ignore lint/suspicious/noExplicitAny: <fix later>
-  payload: any,
-  traceAsync: ReturnType<typeof createTraceAsync>,
+	event: string,
+	// biome-ignore lint/suspicious/noExplicitAny: <fix later>
+	payload: any,
+	traceAsync: ReturnType<typeof createTraceAsync>
 ) {
-  const { installation, repository } = payload;
-  const installationId = installation.id;
-  const repoId = repository.id;
+	const { installation, repository } = payload;
+	const installationId = installation.id;
+	const repoId = repository.id;
 
-  const linked = await traceAsync(
-    "webhook.github.repo_lookup",
-    () =>
-      db.query.githubRepository.findFirst({
-        where: and(
-          eq(schema.githubRepository.installationId, installationId),
-          eq(schema.githubRepository.repoId, repoId),
-          eq(schema.githubRepository.enabled, true),
-        ),
-      }),
-    {
-      description: "Checking if repository is linked",
-      data: { installationId, repoId },
-    },
-  );
+	const linked = await traceAsync(
+		"webhook.github.repo_lookup",
+		() =>
+			db.query.githubRepository.findFirst({
+				where: and(
+					eq(schema.githubRepository.installationId, installationId),
+					eq(schema.githubRepository.repoId, repoId),
+					eq(schema.githubRepository.enabled, true)
+				),
+			}),
+		{
+			description: "Checking if repository is linked",
+			data: { installationId, repoId },
+		}
+	);
 
-  if (!linked) return;
+	if (!linked) return;
 
-  const traceContext = getTraceContext();
+	const traceContext = getTraceContext();
 
-  switch (event) {
-    case "push": {
-      const branch = payload.ref?.replace("refs/heads/", "");
-      if (!branch) return;
+	switch (event) {
+		case "push": {
+			const branch = payload.ref?.replace("refs/heads/", "");
+			if (!branch) return;
 
-      // ✅ Check if this branch belongs to an open PR
-      const existingPr = await db.query.githubPullRequest.findFirst({
-        where: (t) =>
-          and(
-            eq(t.repositoryId, linked.id),
-            eq(t.headBranch, branch),
-            or(eq(t.state, "open"), eq(t.state, "draft")),
-          ),
-      });
+			// ✅ Check if this branch belongs to an open PR
+			const existingPr = await db.query.githubPullRequest.findFirst({
+				where: (t) =>
+					and(
+						eq(t.repositoryId, linked.id),
+						eq(t.headBranch, branch),
+						or(eq(t.state, "open"), eq(t.state, "draft"))
+					),
+			});
 
-      // 🚫 If branch tied to open PR → skip (sync handler will handle it)
-      if (existingPr) {
-        break;
-      }
+			// 🚫 If branch tied to open PR → skip (sync handler will handle it)
+			if (existingPr) {
+				break;
+			}
 
-      // ✅ Normal push flow (non-PR branches)
-      const commits =
-        Array.isArray(payload.commits) && payload.commits.length > 0
-          ? payload.commits
-          : [];
+			// ✅ Normal push flow (non-PR branches)
+			const commits = Array.isArray(payload.commits) && payload.commits.length > 0 ? payload.commits : [];
 
-      if (!commits.length) return;
+			if (!commits.length) return;
 
-      // 🔍 Check if branch is pre-linked to a task
-      const existingBranch = await db.query.githubBranchLink.findFirst({
-        where: (b) =>
-          and(eq(b.repositoryId, linked.id), eq(b.branchName, branch)),
-      });
+			// 🔍 Check if branch is pre-linked to a task
+			const existingBranch = await db.query.githubBranchLink.findFirst({
+				where: (b) => and(eq(b.repositoryId, linked.id), eq(b.branchName, branch)),
+			});
 
-      let branchTaskShortId: number | null = null;
+			let branchTaskShortId: number | null = null;
 
-      if (existingBranch?.taskId) {
-        const branchTask = await db.query.task.findFirst({
-          where: (t) =>
-            and(
-              eq(t.id, existingBranch.taskId as any),
-              eq(t.organizationId, existingBranch.organizationId),
-            ),
-          columns: {
-            shortId: true,
-          },
-        });
+			if (existingBranch?.taskId) {
+				const branchTask = await db.query.task.findFirst({
+					where: (t) =>
+						and(eq(t.id, existingBranch.taskId as any), eq(t.organizationId, existingBranch.organizationId)),
+					columns: {
+						shortId: true,
+					},
+				});
 
-        if (branchTask?.shortId) {
-          branchTaskShortId = branchTask.shortId;
-        }
-      }
+				if (branchTask?.shortId) {
+					branchTaskShortId = branchTask.shortId;
+				}
+			}
 
-      for (const commit of commits) {
-        const message = commit.message?.trim();
-        if (!message) continue;
+			for (const commit of commits) {
+				const message = commit.message?.trim();
+				if (!message) continue;
 
-        const keywordMatches = extractSayrKeywords(message);
+				const keywordMatches = extractSayrKeywords(message);
 
-        // If branch is linked to a task, force-add a match for it
-        if (branchTaskShortId != null) {
-          keywordMatches.push({
-            keyword: "branch",
-            taskKey: branchTaskShortId,
-          });
-        }
+				// If branch is linked to a task, force-add a match for it
+				if (branchTaskShortId != null) {
+					keywordMatches.push({
+						keyword: "branch",
+						taskKey: branchTaskShortId,
+					});
+				}
 
-        if (!keywordMatches.length) continue;
+				if (!keywordMatches.length) continue;
 
-        await enqueue("github", {
-          type: "github_commit_ref",
-          traceContext,
-          payload: {
-            organizationId: linked.organizationId || "",
-            repoOwner: repository.owner.login,
-            repoName: repository.name,
-            repoPrivate: repository.private,
+				await enqueue("github", {
+					type: "github_commit_ref",
+					traceContext,
+					payload: {
+						organizationId: linked.organizationId || "",
+						repoOwner: repository.owner.login,
+						repoName: repository.name,
+						repoPrivate: repository.private,
 
-            commitSha: commit.id,
-            commitUrl: commit.url,
-            commitMessage: message,
-            userId: payload?.sender?.id,
-            authorLogin: commit.author?.username ?? null,
-            authorEmail: commit.author?.email ?? null,
+						commitSha: commit.id,
+						commitUrl: commit.url,
+						commitMessage: message,
+						userId: payload?.sender?.id,
+						authorLogin: commit.author?.username ?? null,
+						authorEmail: commit.author?.email ?? null,
 
-            matches: keywordMatches,
-          },
-        });
-      }
+						matches: keywordMatches,
+					},
+				});
+			}
 
-      break;
-    }
-    case "issues":
-      if (payload.action === "opened") {
-        if (payload.issue.user.login.endsWith("[bot]")) return;
-        await traceAsync(
-          "webhook.github.issue.enqueue",
-          () =>
-            enqueue("github", {
-              type: "sayr_keyword_parse",
-              traceContext,
-              payload: {
-                text: payload.issue.body ?? "",
-                title: payload.issue.title ?? "",
-                owner: repository.owner.login,
-                repoId: repository.id,
-                repo: repository.name,
-                repo_private: repository.private,
-                number: payload.issue.number,
-                installationId,
-                eventType: "issue",
-                organizationId: linked.organizationId,
-                categoryId: linked.categoryId,
-              },
-            }),
-          {
-            description: "Enqueueing issue for processing",
-            data: {
-              issueNumber: payload.issue.number,
-              repoId,
-              organizationId: linked.organizationId,
-              traceId: traceContext?.traceId,
-            },
-            onSuccess: () => ({
-              outcome: "Issue enqueued successfully",
-              data: { issueNumber: payload.issue.number },
-            }),
-          },
-        );
-      }
-      break;
+			break;
+		}
+		case "issues":
+			if (payload.action === "opened") {
+				if (payload.issue.user.login.endsWith("[bot]")) return;
+				await traceAsync(
+					"webhook.github.issue.enqueue",
+					() =>
+						enqueue("github", {
+							type: "sayr_keyword_parse",
+							traceContext,
+							payload: {
+								text: payload.issue.body ?? "",
+								title: payload.issue.title ?? "",
+								owner: repository.owner.login,
+								repoId: repository.id,
+								repo: repository.name,
+								repo_private: repository.private,
+								number: payload.issue.number,
+								installationId,
+								eventType: "issue",
+								organizationId: linked.organizationId,
+								categoryId: linked.categoryId,
+							},
+						}),
+					{
+						description: "Enqueueing issue for processing",
+						data: {
+							issueNumber: payload.issue.number,
+							repoId,
+							organizationId: linked.organizationId,
+							traceId: traceContext?.traceId,
+						},
+						onSuccess: () => ({
+							outcome: "Issue enqueued successfully",
+							data: { issueNumber: payload.issue.number },
+						}),
+					}
+				);
+			} else if (payload.action === "edited") {
+				// `sender` is the actual editor for "edited" actions — `issue.user`
+				// is always the original issue author, which would never bot-guard
+				// an edit made by the Sayr bot itself (loop risk).
+				if (payload.sender?.login?.endsWith("[bot]")) return;
+				await traceAsync(
+					"webhook.github.issue_edited.enqueue",
+					() =>
+						enqueue("github", {
+							type: "issue_edited",
+							traceContext,
+							payload: {
+								owner: repository.owner.login,
+								repoId: repository.id,
+								repo: repository.name,
+								repo_private: repository.private,
+								organizationId: linked.organizationId,
+								number: payload.issue.number,
+								title: payload.issue.title ?? "",
+								body: payload.issue.body ?? "",
+								user: payload.sender?.login ?? "unknown",
+							},
+						}),
+					{
+						description: "Enqueueing edited issue for processing",
+						data: {
+							issueNumber: payload.issue.number,
+							repoId,
+							organizationId: linked.organizationId,
+							traceId: traceContext?.traceId,
+						},
+						onSuccess: () => ({
+							outcome: "Edited issue enqueued successfully",
+							data: { issueNumber: payload.issue.number },
+						}),
+					}
+				);
+			}
+			break;
 
-    case "issue_comment":
-      if (payload.action === "created") {
-        const issueNum = payload.issue.number;
-        const commenter = payload.comment?.user?.login ?? "unknown";
-        const commenterId = payload.comment?.user?.id;
-        const body = payload.comment?.body?.trim() ?? "";
+		case "issue_comment":
+			if (payload.action === "created") {
+				const issueNum = payload.issue.number;
+				const commenter = payload.comment?.user?.login ?? "unknown";
+				const commenterId = payload.comment?.user?.id;
+				const body = payload.comment?.body?.trim() ?? "";
 
-        if (!body) return;
-        if (commenter.endsWith("[bot]")) return;
+				if (!body) return;
+				if (commenter.endsWith("[bot]")) return;
 
-        const keywordMatches = extractSayrKeywords(body);
+				const keywordMatches = extractSayrKeywords(body);
 
-        // ---------------------------
-        // CASE 1: KEYWORDS → automation
-        // ---------------------------
-        if (keywordMatches.length > 0) {
-          await enqueue("github", {
-            type: "sayr_keyword_parse",
-            traceContext,
-            payload: {
-              text: body,
-              title: "",
-              eventType: "comment",
-              number: issueNum,
-              owner: repository.owner.login,
-              repo: repository.name,
-              repoId: repository.id,
-              repo_private: repository.private,
-              installationId,
-              merged: false,
-              organizationId: linked.organizationId,
-              categoryId: linked.categoryId,
-            },
-          });
+				// ---------------------------
+				// CASE 1: KEYWORDS → automation
+				// ---------------------------
+				if (keywordMatches.length > 0) {
+					await enqueue("github", {
+						type: "sayr_keyword_parse",
+						traceContext,
+						payload: {
+							text: body,
+							title: "",
+							eventType: "comment",
+							number: issueNum,
+							owner: repository.owner.login,
+							repo: repository.name,
+							repoId: repository.id,
+							repo_private: repository.private,
+							installationId,
+							merged: false,
+							organizationId: linked.organizationId,
+							categoryId: linked.categoryId,
+						},
+					});
 
-          return;
-        }
+					return;
+				}
 
-        // ---------------------------
-        // CASE 2: NO KEYWORDS → comment sync
-        // ---------------------------
-        await enqueue("github", {
-          type: "issue_comment",
-          traceContext,
-          payload: {
-            owner: repository.owner.login,
-            repo: repository.name,
-            repoId: repository.id,
-            repo_private: repository.private,
-            organizationId: linked.organizationId,
-            number: issueNum,
-            commentId: payload.comment.id,
-            commentBody: payload.comment.body ?? "",
-            user: commenter,
-            userId: commenterId,
-            pull_request: repository.has_pull_requests,
-          },
-        });
-      }
-      break;
-    case "create": {
-      const author = payload.sender?.login ?? "";
-      if (author.endsWith("[bot]")) return;
-      const type = payload.ref_type;
-      if (type === "branch") {
-        const branch = payload.ref;
-        const sayrRepositoryTable = await db.query.githubRepository.findFirst({
-          where: eq(schema.githubRepository.repoId, repoId),
-          with: {
-            organization: {
-              columns: {
-                shortId: true,
-              },
-            },
-          },
-        });
-        // Try to pull a task key from the branch name, e.g. "sayr16", "sayr-16"
-        const branchPrefix =
-          sayrRepositoryTable?.organization?.shortId ?? "SAY"; // fallback if needed
-        console.log("🚀 ~ handleContentEvents ~ branchPrefix:", branchPrefix);
-        const escapedPrefix = branchPrefix.replace(
-          /[.*+?^${}()|[\]\\]/g,
-          "\\$&",
-        );
-        // Matches: PREFIX16, PREFIX-16, PREFIX_16 anywhere in branch path
-        // e.g. "feature/SAY16-foo", "bugfix/XXX-42"
-        const prefixRegex = new RegExp(
-          String.raw`(?:^|[\/\-_])(${escapedPrefix})[\-_]?(\d+)\b`,
-          "i",
-        );
-        const branchMatch = branch.match(prefixRegex);
-        if (branchMatch) {
-          const branchTaskKey = Number(branchMatch[2]);
-          if (!Number.isNaN(branchTaskKey)) {
-            await enqueue("github", {
-              type: "branch_create",
-              traceContext,
-              payload: {
-                linkedId: linked.id,
-                organizationId: linked.organizationId,
+				// ---------------------------
+				// CASE 2: NO KEYWORDS → comment sync
+				// ---------------------------
+				await enqueue("github", {
+					type: "issue_comment",
+					traceContext,
+					payload: {
+						owner: repository.owner.login,
+						repo: repository.name,
+						repoId: repository.id,
+						repo_private: repository.private,
+						organizationId: linked.organizationId,
+						number: issueNum,
+						commentId: payload.comment.id,
+						commentBody: payload.comment.body ?? "",
+						user: commenter,
+						userId: commenterId,
+						pull_request: repository.has_pull_requests,
+					},
+				});
+			} else if (payload.action === "edited") {
+				// Note: we deliberately do NOT re-run keyword-parse here — only
+				// "created" triggers that. Re-running it on edit risks
+				// double-closing/relinking tasks from the same keyword.
+				const commenter = payload.comment?.user?.login ?? "unknown";
+				if (commenter.endsWith("[bot]")) return;
 
-                owner: repository.owner.login,
-                repo: repository.name,
-                repoId: repository.id,
-                repo_private: repository.private,
-                branch: branch,
+				await enqueue("github", {
+					type: "issue_comment_edited",
+					traceContext,
+					payload: {
+						owner: repository.owner.login,
+						repo: repository.name,
+						repoId: repository.id,
+						repo_private: repository.private,
+						organizationId: linked.organizationId,
+						number: payload.issue.number,
+						commentId: payload.comment.id,
+						commentBody: payload.comment.body ?? "",
+						user: commenter,
+						userId: payload.comment?.user?.id,
+						pull_request: repository.has_pull_requests,
+					},
+				});
+			} else if (payload.action === "deleted") {
+				const commenter = payload.comment?.user?.login ?? "unknown";
+				if (commenter.endsWith("[bot]")) return;
 
-                userId: payload.sender?.id,
-                author,
-                taskKey: branchTaskKey,
-              },
-            });
-          }
-        }
-      }
-      break;
-    }
-    case "delete": {
-      const author = payload.sender?.login ?? "";
-      if (author.endsWith("[bot]")) return;
-      const type = payload.ref_type;
-      if (type === "branch") {
-        const branch = payload.ref;
-        const sayrRepositoryTable = await db.query.githubRepository.findFirst({
-          where: eq(schema.githubRepository.repoId, repoId),
-          with: {
-            organization: {
-              columns: {
-                shortId: true,
-              },
-            },
-          },
-        });
-        // Try to pull a task key from the branch name, e.g. "sayr16", "sayr-16"
-        const branchPrefix =
-          sayrRepositoryTable?.organization?.shortId ?? "SAY"; // fallback if needed
-        const escapedPrefix = branchPrefix.replace(
-          /[.*+?^${}()|[\]\\]/g,
-          "\\$&",
-        );
-        // Matches: PREFIX16, PREFIX-16, PREFIX_16 anywhere in branch path
-        // e.g. "feature/SAY16-foo", "bugfix/XXX-42"
-        const prefixRegex = new RegExp(
-          String.raw`(?:^|[\/\-_])(${escapedPrefix})[\-_]?(\d+)\b`,
-          "i",
-        );
-        const branchMatch = branch.match(prefixRegex);
-        if (branchMatch) {
-          const branchTaskKey = Number(branchMatch[2]);
-          if (!Number.isNaN(branchTaskKey)) {
-            await enqueue("github", {
-              type: "branch_delete",
-              traceContext,
-              payload: {
-                linkedId: linked.id,
-                organizationId: linked.organizationId,
+				await enqueue("github", {
+					type: "issue_comment_deleted",
+					traceContext,
+					payload: {
+						owner: repository.owner.login,
+						repo: repository.name,
+						repoId: repository.id,
+						repo_private: repository.private,
+						organizationId: linked.organizationId,
+						number: payload.issue.number,
+						commentId: payload.comment.id,
+						user: commenter,
+						userId: payload.comment?.user?.id,
+						pull_request: repository.has_pull_requests,
+					},
+				});
+			}
+			break;
+		case "create": {
+			const author = payload.sender?.login ?? "";
+			if (author.endsWith("[bot]")) return;
+			const type = payload.ref_type;
+			if (type === "branch") {
+				const branch = payload.ref;
+				const sayrRepositoryTable = await db.query.githubRepository.findFirst({
+					where: eq(schema.githubRepository.repoId, repoId),
+					with: {
+						organization: {
+							columns: {
+								shortId: true,
+							},
+						},
+					},
+				});
+				// Try to pull a task key from the branch name, e.g. "sayr16", "sayr-16"
+				const branchPrefix = sayrRepositoryTable?.organization?.shortId ?? "SAY"; // fallback if needed
+				console.log("🚀 ~ handleContentEvents ~ branchPrefix:", branchPrefix);
+				const escapedPrefix = branchPrefix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+				// Matches: PREFIX16, PREFIX-16, PREFIX_16 anywhere in branch path
+				// e.g. "feature/SAY16-foo", "bugfix/XXX-42"
+				const prefixRegex = new RegExp(String.raw`(?:^|[\/\-_])(${escapedPrefix})[\-_]?(\d+)\b`, "i");
+				const branchMatch = branch.match(prefixRegex);
+				if (branchMatch) {
+					const branchTaskKey = Number(branchMatch[2]);
+					if (!Number.isNaN(branchTaskKey)) {
+						await enqueue("github", {
+							type: "branch_create",
+							traceContext,
+							payload: {
+								linkedId: linked.id,
+								organizationId: linked.organizationId,
 
-                owner: repository.owner.login,
-                repo: repository.name,
-                repoId: repository.id,
-                repo_private: repository.private,
-                branch: branch,
+								owner: repository.owner.login,
+								repo: repository.name,
+								repoId: repository.id,
+								repo_private: repository.private,
+								branch: branch,
 
-                userId: payload.sender?.id,
-                author,
-                taskKey: branchTaskKey,
-              },
-            });
-          }
-        }
-      }
-      break;
-    }
-    case "pull_request": {
-      const action = payload.action;
-      const pr = payload.pull_request;
+								userId: payload.sender?.id,
+								author,
+								taskKey: branchTaskKey,
+							},
+						});
+					}
+				}
+			}
+			break;
+		}
+		case "delete": {
+			const author = payload.sender?.login ?? "";
+			if (author.endsWith("[bot]")) return;
+			const type = payload.ref_type;
+			if (type === "branch") {
+				const branch = payload.ref;
+				const sayrRepositoryTable = await db.query.githubRepository.findFirst({
+					where: eq(schema.githubRepository.repoId, repoId),
+					with: {
+						organization: {
+							columns: {
+								shortId: true,
+							},
+						},
+					},
+				});
+				// Try to pull a task key from the branch name, e.g. "sayr16", "sayr-16"
+				const branchPrefix = sayrRepositoryTable?.organization?.shortId ?? "SAY"; // fallback if needed
+				const escapedPrefix = branchPrefix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+				// Matches: PREFIX16, PREFIX-16, PREFIX_16 anywhere in branch path
+				// e.g. "feature/SAY16-foo", "bugfix/XXX-42"
+				const prefixRegex = new RegExp(String.raw`(?:^|[\/\-_])(${escapedPrefix})[\-_]?(\d+)\b`, "i");
+				const branchMatch = branch.match(prefixRegex);
+				if (branchMatch) {
+					const branchTaskKey = Number(branchMatch[2]);
+					if (!Number.isNaN(branchTaskKey)) {
+						await enqueue("github", {
+							type: "branch_delete",
+							traceContext,
+							payload: {
+								linkedId: linked.id,
+								organizationId: linked.organizationId,
 
-      const prNumber = pr.number;
-      const prTitle = pr.title ?? "";
-      const prBody = pr.body ?? "";
-      const merged = pr.merged ?? false;
+								owner: repository.owner.login,
+								repo: repository.name,
+								repoId: repository.id,
+								repo_private: repository.private,
+								branch: branch,
 
-      // Only care about lifecycle + new commits
-      if (
-        ![
-          "opened",
-          "reopened",
-          "synchronize",
-          "closed",
-          "ready_for_review",
-          "converted_to_draft",
-        ].includes(action)
-      ) {
-        return;
-      }
+								userId: payload.sender?.id,
+								author,
+								taskKey: branchTaskKey,
+							},
+						});
+					}
+				}
+			}
+			break;
+		}
+		case "pull_request": {
+			const action = payload.action;
+			const pr = payload.pull_request;
 
-      // Ignore bot PRs
-      const author = pr.user?.login ?? "";
-      if (author.endsWith("[bot]")) return;
+			const prNumber = pr.number;
+			const prTitle = pr.title ?? "";
+			const prBody = pr.body ?? "";
+			const merged = pr.merged ?? false;
 
-      // Extract keywords from title + body
-      const keywordMatches = extractSayrKeywords(`${prTitle}\n${prBody}`);
+			// Only care about lifecycle + new commits
+			if (
+				!["opened", "reopened", "synchronize", "closed", "ready_for_review", "converted_to_draft"].includes(action)
+			) {
+				return;
+			}
 
-      // ----------------------------------------
-      // 1️⃣ PR OPENED / REOPENED
-      // ----------------------------------------
-      if (
-        action === "opened" ||
-        action === "reopened" ||
-        action === "ready_for_review" ||
-        action === "converted_to_draft"
-      ) {
-        await enqueue("github", {
-          type: "pull_request_link",
-          traceContext,
-          payload: {
-            linkedId: linked.id,
-            organizationId: linked.organizationId,
+			// Ignore bot PRs
+			const author = pr.user?.login ?? "";
+			if (author.endsWith("[bot]")) return;
 
-            owner: repository.owner.login,
-            repo: repository.name,
-            repoId: repository.id,
-            repo_private: repository.private,
+			// Extract keywords from title + body
+			const keywordMatches = extractSayrKeywords(`${prTitle}\n${prBody}`);
 
-            number: prNumber,
-            title: prTitle,
-            body: prBody,
-            draft: pr.draft,
-            state: pr.state,
+			// ----------------------------------------
+			// 1️⃣ PR OPENED / REOPENED
+			// ----------------------------------------
+			if (
+				action === "opened" ||
+				action === "reopened" ||
+				action === "ready_for_review" ||
+				action === "converted_to_draft"
+			) {
+				await enqueue("github", {
+					type: "pull_request_link",
+					traceContext,
+					payload: {
+						linkedId: linked.id,
+						organizationId: linked.organizationId,
 
-            headSha: pr.head.sha,
-            baseRef: pr.base.ref,
-            headRef: pr.head.ref,
-            headBranch: pr.head.ref,
-            baseBranch: pr.base.ref,
+						owner: repository.owner.login,
+						repo: repository.name,
+						repoId: repository.id,
+						repo_private: repository.private,
 
-            userId: payload.sender?.id,
-            author,
-            matches: keywordMatches,
-          },
-        });
+						number: prNumber,
+						title: prTitle,
+						body: prBody,
+						draft: pr.draft,
+						state: pr.state,
 
-        return;
-      }
+						headSha: pr.head.sha,
+						baseRef: pr.base.ref,
+						headRef: pr.head.ref,
+						headBranch: pr.head.ref,
+						baseBranch: pr.base.ref,
 
-      // ----------------------------------------
-      // 2️⃣ NEW COMMITS PUSHED TO PR
-      // ----------------------------------------
-      if (action === "synchronize") {
-        await enqueue("github", {
-          type: "pull_request_sync",
-          traceContext,
-          payload: {
-            linkedId: linked.id,
-            organizationId: linked.organizationId,
-            owner: repository.owner.login,
-            repo: repository.name,
-            repoId: repository.id,
-            repo_private: repository.private,
+						userId: payload.sender?.id,
+						author,
+						matches: keywordMatches,
+					},
+				});
 
-            number: prNumber,
-            headSha: pr.head.sha,
-            before: payload.before,
-            after: payload.after,
-            userId: payload.sender?.id,
+				return;
+			}
 
-            headBranch: pr.head.ref,
-          },
-        });
+			// ----------------------------------------
+			// 2️⃣ NEW COMMITS PUSHED TO PR
+			// ----------------------------------------
+			if (action === "synchronize") {
+				await enqueue("github", {
+					type: "pull_request_sync",
+					traceContext,
+					payload: {
+						linkedId: linked.id,
+						organizationId: linked.organizationId,
+						owner: repository.owner.login,
+						repo: repository.name,
+						repoId: repository.id,
+						repo_private: repository.private,
 
-        return;
-      }
+						number: prNumber,
+						headSha: pr.head.sha,
+						before: payload.before,
+						after: payload.after,
+						userId: payload.sender?.id,
 
-      // ----------------------------------------
-      // 3️⃣ PR CLOSED (Merged detection)
-      // ----------------------------------------
-      if (action === "closed") {
-        await enqueue("github", {
-          type: "pull_request_closed",
-          traceContext,
-          payload: {
-            linkedId: linked.id,
-            organizationId: linked.organizationId,
-            owner: repository.owner.login,
-            repo: repository.name,
-            repoId: repository.id,
-            repo_private: repository.private,
-            userId: payload.sender?.id,
+						headBranch: pr.head.ref,
+					},
+				});
 
-            number: prNumber,
-            merged,
-            mergedAt: pr.merged_at,
-            mergeCommitSha: pr.merge_commit_sha,
-          },
-        });
+				return;
+			}
 
-        return;
-      }
+			// ----------------------------------------
+			// 3️⃣ PR CLOSED (Merged detection)
+			// ----------------------------------------
+			if (action === "closed") {
+				await enqueue("github", {
+					type: "pull_request_closed",
+					traceContext,
+					payload: {
+						linkedId: linked.id,
+						organizationId: linked.organizationId,
+						owner: repository.owner.login,
+						repo: repository.name,
+						repoId: repository.id,
+						repo_private: repository.private,
+						userId: payload.sender?.id,
 
-      break;
-    }
-    default:
-      break;
-  }
+						number: prNumber,
+						merged,
+						mergedAt: pr.merged_at,
+						mergeCommitSha: pr.merge_commit_sha,
+					},
+				});
+
+				return;
+			}
+
+			break;
+		}
+		default:
+			break;
+	}
 }
 
 export type KeywordMatch = {
-  keyword: string;
-  taskKey: number;
+	keyword: string;
+	taskKey: number;
 };
 
 // ✅ Supports: "Ref 10", "Ref #10", "Fixes SA-123", "Sayr 42"
 export function extractSayrKeywords(text: string): KeywordMatch[] {
-  if (!text) return [];
+	if (!text) return [];
 
-  // Only match digits for the second capture group.
-  // Will handle "Fixes 10", "Ref #15", "Sayr 42" etc.
-  const regex =
-    /\b(?:(Fixes|Fixed|Closes|Closed|Resolves|Resolved|Blocked by|Ref|Sayr)[\s:#-]*)#?(\d+)\b/gi;
+	// Only match digits for the second capture group.
+	// Will handle "Fixes 10", "Ref #15", "Sayr 42" etc.
+	const regex = /\b(?:(Fixes|Fixed|Closes|Closed|Resolves|Resolved|Blocked by|Ref|Sayr)[\s:#-]*)#?(\d+)\b/gi;
 
-  const matches: KeywordMatch[] = [];
+	const matches: KeywordMatch[] = [];
 
-  for (; ;) {
-    const result = regex.exec(text);
-    if (result === null) break;
+	for (;;) {
+		const result = regex.exec(text);
+		if (result === null) break;
 
-    const taskKey = Number(result[2]); // force numeric
+		const taskKey = Number(result[2]); // force numeric
 
-    // Skip invalid conversions (NaN guard)
-    if (Number.isNaN(taskKey)) continue;
+		// Skip invalid conversions (NaN guard)
+		if (Number.isNaN(taskKey)) continue;
 
-    matches.push({
-      keyword: result[1] ?? "",
-      taskKey,
-    });
-  }
+		matches.push({
+			keyword: result[1] ?? "",
+			taskKey,
+		});
+	}
 
-  return matches;
+	return matches;
 }

--- a/apps/backend/routes/webhook/github.ts
+++ b/apps/backend/routes/webhook/github.ts
@@ -5,7 +5,7 @@ import { enqueue } from "@repo/queue";
 import { verifySignature } from "@repo/util/github/verify";
 import { and, eq, or } from "drizzle-orm";
 import { Hono } from "hono";
-import { SAYR_COMMENT_SYNC_MARKER } from "@/util";
+import { SAYR_COMMENT_SYNC_MARKER, SAYR_TASK_LINK_MARKER_PREFIX } from "@/util";
 
 const app = new Hono<AppEnv>();
 app.post("/", async (c) => {
@@ -215,28 +215,83 @@ async function handleContentEvents(
 		case "issues":
 			if (payload.action === "opened") {
 				if (payload.issue.user.login.endsWith("[bot]")) return;
+
+				const issueBody = payload.issue.body ?? "";
+				// An issue Sayr itself opened (from a public task) carries this
+				// marker in its body — never treat it as new, or we'd spin up a
+				// second, duplicate task for it.
+				if (issueBody.includes(SAYR_TASK_LINK_MARKER_PREFIX)) return;
+
+				const keywordMatches = extractSayrKeywords(issueBody);
+
+				// ---------------------------
+				// CASE 1: KEYWORDS → link to the existing task they reference,
+				// same as `issue_comment`. Don't also create a new task.
+				// ---------------------------
+				if (keywordMatches.length > 0) {
+					await traceAsync(
+						"webhook.github.issue.enqueue",
+						() =>
+							enqueue("github", {
+								type: "sayr_keyword_parse",
+								traceContext,
+								payload: {
+									text: issueBody,
+									title: payload.issue.title ?? "",
+									owner: repository.owner.login,
+									repoId: repository.id,
+									repo: repository.name,
+									repo_private: repository.private,
+									number: payload.issue.number,
+									installationId,
+									eventType: "issue",
+									organizationId: linked.organizationId,
+									categoryId: linked.categoryId,
+								},
+							}),
+						{
+							description: "Enqueueing issue for processing",
+							data: {
+								issueNumber: payload.issue.number,
+								repoId,
+								organizationId: linked.organizationId,
+								traceId: traceContext?.traceId,
+							},
+							onSuccess: () => ({
+								outcome: "Issue enqueued successfully",
+								data: { issueNumber: payload.issue.number },
+							}),
+						}
+					);
+					return;
+				}
+
+				// ---------------------------
+				// CASE 2: NO KEYWORDS → this is a brand-new issue with no
+				// existing task to link to. Create one.
+				// ---------------------------
 				await traceAsync(
-					"webhook.github.issue.enqueue",
+					"webhook.github.issue_opened.enqueue",
 					() =>
 						enqueue("github", {
-							type: "sayr_keyword_parse",
+							type: "issue_opened",
 							traceContext,
 							payload: {
-								text: payload.issue.body ?? "",
-								title: payload.issue.title ?? "",
 								owner: repository.owner.login,
 								repoId: repository.id,
 								repo: repository.name,
 								repo_private: repository.private,
-								number: payload.issue.number,
-								installationId,
-								eventType: "issue",
 								organizationId: linked.organizationId,
 								categoryId: linked.categoryId,
+								number: payload.issue.number,
+								title: payload.issue.title ?? "",
+								body: issueBody,
+								user: payload.issue.user.login,
+								userId: payload.issue.user.id,
 							},
 						}),
 					{
-						description: "Enqueueing issue for processing",
+						description: "Enqueueing new issue for task creation",
 						data: {
 							issueNumber: payload.issue.number,
 							repoId,
@@ -244,7 +299,7 @@ async function handleContentEvents(
 							traceId: traceContext?.traceId,
 						},
 						onSuccess: () => ({
-							outcome: "Issue enqueued successfully",
+							outcome: "Issue enqueued for task creation",
 							data: { issueNumber: payload.issue.number },
 						}),
 					}

--- a/apps/backend/routes/webhook/github.ts
+++ b/apps/backend/routes/webhook/github.ts
@@ -283,6 +283,7 @@ async function handleContentEvents(
 								repo_private: repository.private,
 								organizationId: linked.organizationId,
 								categoryId: linked.categoryId,
+								installationId,
 								number: payload.issue.number,
 								title: payload.issue.title ?? "",
 								body: issueBody,

--- a/apps/backend/util.ts
+++ b/apps/backend/util.ts
@@ -29,9 +29,7 @@ export async function getOrganization(orgId: string, userId: string): Promise<{ 
 }
 
 export async function safeGetOrganization(orgId: string, userId: string, ms = 5000) {
-	const timeoutPromise = new Promise<null>((_, reject) =>
-		setTimeout(() => reject(new Error("Timeout")), ms)
-	);
+	const timeoutPromise = new Promise<null>((_, reject) => setTimeout(() => reject(new Error("Timeout")), ms));
 
 	try {
 		return await Promise.race([getOrganization(orgId, userId), timeoutPromise]);
@@ -39,13 +37,22 @@ export async function safeGetOrganization(orgId: string, userId: string, ms = 50
 		const isTimeout = err instanceof Error && err.message === "Timeout";
 		console.warn(
 			`[safeGetOrganization] ${isTimeout ? "TIMEOUT" : "ERROR"} for org=${orgId} user=${userId}:`,
-			isTimeout ? `exceeded ${ms}ms` : err,
+			isTimeout ? `exceeded ${ms}ms` : err
 		);
 		return null;
 	}
 }
 
 // biome-ignore lint/suspicious/noExplicitAny: <need for the cursor>
+// Invisible marker appended to every comment Sayr pushes to GitHub — HTML
+// comments don't render, so it's not visible to anyone reading the issue.
+// Its only job is loop prevention: when the resulting `issue_comment` webhook
+// fires back at us (unavoidable even when posting via a linked user's own
+// GitHub token, since that comment then has a real, non-bot `user.login`),
+// the webhook handler checks for this marker and skips re-processing it as a
+// brand-new inbound comment.
+export const SAYR_COMMENT_SYNC_MARKER = "<!-- sayr-comment-sync -->";
+
 export function encodeCursor(obj: Record<string, any>): string {
 	return Buffer.from(JSON.stringify(obj)).toString("base64url");
 }
@@ -107,34 +114,20 @@ export async function traceOrgPermissionCheck(
 		return false;
 	}
 
-	return traceAsync(
-		"hasOrgPermission",
-		() =>
-			hasOrgPermission(
-				userId,
-				organizationId,
-				permission
-			),
-		{
-			description: "Checking organization permissions",
-			data: {
-				user: { id: userId },
-				organization: { id: organizationId },
-				permission,
-			},
-			onSuccess: (result) => ({
-				outcome: result
-					? "Permission granted"
-					: "Permission denied",
-			}),
-		}
-	);
+	return traceAsync("hasOrgPermission", () => hasOrgPermission(userId, organizationId, permission), {
+		description: "Checking organization permissions",
+		data: {
+			user: { id: userId },
+			organization: { id: organizationId },
+			permission,
+		},
+		onSuccess: (result) => ({
+			outcome: result ? "Permission granted" : "Permission denied",
+		}),
+	});
 }
 
-type PublicAccessCheck =
-	| "enablePublicPage"
-	| "publicActions"
-	| "both";
+type PublicAccessCheck = "enablePublicPage" | "publicActions" | "both";
 
 export async function tracePublicOrgAccessCheck(
 	organizationId: string,
@@ -146,22 +139,16 @@ export async function tracePublicOrgAccessCheck(
 		return false;
 	}
 
-	return traceAsync(
-		"canPublicAccessOrg",
-		() => canPublicAccessOrg(organizationId, check),
-		{
-			description: "Checking public organization access",
-			data: {
-				organization: { id: organizationId },
-				check,
-			},
-			onSuccess: (result) => ({
-				outcome: result
-					? "Public access allowed"
-					: "Public access denied",
-			}),
-		}
-	);
+	return traceAsync("canPublicAccessOrg", () => canPublicAccessOrg(organizationId, check), {
+		description: "Checking public organization access",
+		data: {
+			organization: { id: organizationId },
+			check,
+		},
+		onSuccess: (result) => ({
+			outcome: result ? "Public access allowed" : "Public access denied",
+		}),
+	});
 }
 
 export async function refreshGitHubTokenIfNeeded(githubAccount: schema.accountType) {
@@ -170,11 +157,7 @@ export async function refreshGitHubTokenIfNeeded(githubAccount: schema.accountTy
 	const now = new Date();
 
 	// still valid → no refresh
-	if (
-		githubAccount.accessToken &&
-		githubAccount.accessTokenExpiresAt &&
-		githubAccount.accessTokenExpiresAt > now
-	) {
+	if (githubAccount.accessToken && githubAccount.accessTokenExpiresAt && githubAccount.accessTokenExpiresAt > now) {
 		return githubAccount;
 	}
 
@@ -199,9 +182,7 @@ export async function refreshGitHubTokenIfNeeded(githubAccount: schema.accountTy
 			throw new Error("Failed refresh GitHub token");
 		}
 
-		const expiresAt = data.expires_in
-			? new Date(Date.now() + data.expires_in * 1000)
-			: null;
+		const expiresAt = data.expires_in ? new Date(Date.now() + data.expires_in * 1000) : null;
 
 		const refreshExpiresAt = data.refresh_token_expires_in
 			? new Date(Date.now() + data.refresh_token_expires_in * 1000)

--- a/apps/backend/util.ts
+++ b/apps/backend/util.ts
@@ -53,6 +53,13 @@ export async function safeGetOrganization(orgId: string, userId: string, ms = 50
 // brand-new inbound comment.
 export const SAYR_COMMENT_SYNC_MARKER = "<!-- sayr-comment-sync -->";
 
+// Prefix of the invisible marker embedded in every GitHub issue body Sayr
+// creates (see the `task.create.github_sync` block). Checking for it on
+// inbound `issues` webhooks is what stops an issue Sayr itself just opened
+// from being mistaken for a brand-new external issue and turned into a
+// second, duplicate task.
+export const SAYR_TASK_LINK_MARKER_PREFIX = "<!-- sayr-task:";
+
 export function encodeCursor(obj: Record<string, any>): string {
 	return Buffer.from(JSON.stringify(obj)).toString("base64url");
 }

--- a/apps/worker/github/basicGithubSchema.ts
+++ b/apps/worker/github/basicGithubSchema.ts
@@ -1,147 +1,158 @@
 import { Schema } from "prosemirror-model";
 
 export const basicGithubSchema = new Schema({
-    nodes: {
-        doc: {
-            content: "block+",
-        },
+	nodes: {
+		doc: {
+			content: "block+",
+		},
 
-        text: {
-            group: "inline",
-        },
+		text: {
+			group: "inline",
+		},
 
-        paragraph: {
-            group: "block",
-            content: "inline*",
-            toDOM() {
-                return ["p", 0];
-            },
-        },
+		paragraph: {
+			group: "block",
+			content: "inline*",
+			toDOM() {
+				return ["p", 0];
+			},
+		},
 
-        heading: {
-            group: "block",
-            content: "inline*",
-            attrs: {
-                level: { default: 1 },
-            },
-            toDOM(node) {
-                return ["h" + node.attrs.level, 0];
-            },
-        },
+		heading: {
+			group: "block",
+			content: "inline*",
+			attrs: {
+				level: { default: 1 },
+			},
+			toDOM(node) {
+				return ["h" + node.attrs.level, 0];
+			},
+		},
 
-        blockquote: {
-            group: "block",
-            content: "block+",
-            toDOM() {
-                return ["blockquote", 0];
-            },
-        },
+		blockquote: {
+			group: "block",
+			content: "block+",
+			toDOM() {
+				return ["blockquote", 0];
+			},
+		},
 
-        horizontalRule: {
-            group: "block",
-            toDOM() {
-                return ["hr"];
-            },
-        },
+		horizontalRule: {
+			group: "block",
+			toDOM() {
+				return ["hr"];
+			},
+		},
 
-        codeBlock: {
-            group: "block",
-            content: "text*",
-            attrs: {
-                language: { default: null },
-            },
-            code: true,
-            toDOM(node) {
-                return [
-                    "pre",
-                    node.attrs.language
-                        ? ["code", { "data-language": node.attrs.language }, 0]
-                        : ["code", 0],
-                ];
-            },
-        },
+		codeBlock: {
+			group: "block",
+			content: "text*",
+			attrs: {
+				language: { default: null },
+			},
+			code: true,
+			toDOM(node) {
+				return ["pre", node.attrs.language ? ["code", { "data-language": node.attrs.language }, 0] : ["code", 0]];
+			},
+		},
 
-        bulletList: {
-            group: "block",
-            content: "listItem+",
-            toDOM() {
-                return ["ul", 0];
-            },
-        },
+		bulletList: {
+			group: "block",
+			content: "listItem+",
+			toDOM() {
+				return ["ul", 0];
+			},
+		},
 
-        orderedList: {
-            group: "block",
-            content: "listItem+",
-            attrs: {
-                start: { default: 1 },
-            },
-            toDOM(node) {
-                return [
-                    "ol",
-                    node.attrs.start === 1 ? {} : { start: node.attrs.start },
-                    0,
-                ];
-            },
-        },
+		orderedList: {
+			group: "block",
+			content: "listItem+",
+			attrs: {
+				start: { default: 1 },
+			},
+			toDOM(node) {
+				return ["ol", node.attrs.start === 1 ? {} : { start: node.attrs.start }, 0];
+			},
+		},
 
-        listItem: {
-            content: "block+",
-            toDOM() {
-                return ["li", 0];
-            },
-        },
+		listItem: {
+			content: "block+",
+			toDOM() {
+				return ["li", 0];
+			},
+		},
 
-        hardBreak: {
-            inline: true,
-            group: "inline",
-            selectable: false,
-            toDOM() {
-                return ["br"];
-            },
-        },
-    },
+		hardBreak: {
+			inline: true,
+			group: "inline",
+			selectable: false,
+			toDOM() {
+				return ["br"];
+			},
+		},
 
-    marks: {
-        bold: {
-            toDOM() {
-                return ["strong", 0];
-            },
-        },
+		// Only ever constructed programmatically (see resolveGithubIssueReferences
+		// in markdownToProsekit.ts) when a bare `#123` reference in incoming
+		// GitHub markdown resolves to a linked Sayr task — never parsed from
+		// markdown syntax directly. Attrs mirror the frontend's mention node
+		// (apps/backend/prosekit/schema.ts) so the resulting JSON renders with
+		// the same TaskMention UI once it lands in a task's description/comments.
+		mention: {
+			group: "inline",
+			inline: true,
+			atom: true,
+			attrs: {
+				id: { default: null },
+				value: { default: "" },
+				kind: { default: null },
+			},
+			toDOM(node) {
+				return ["span", { "data-mention": node.attrs.kind, "data-id": node.attrs.id }, node.attrs.value];
+			},
+		},
+	},
 
-        italic: {
-            toDOM() {
-                return ["em", 0];
-            },
-        },
+	marks: {
+		bold: {
+			toDOM() {
+				return ["strong", 0];
+			},
+		},
 
-        strike: {
-            toDOM() {
-                return ["s", 0];
-            },
-        },
+		italic: {
+			toDOM() {
+				return ["em", 0];
+			},
+		},
 
-        code: {
-            toDOM() {
-                return ["code", 0];
-            },
-        },
+		strike: {
+			toDOM() {
+				return ["s", 0];
+			},
+		},
 
-        link: {
-            attrs: {
-                href: {},
-                title: { default: null },
-            },
-            inclusive: false,
-            toDOM(mark) {
-                return [
-                    "a",
-                    {
-                        href: mark.attrs.href,
-                        title: mark.attrs.title,
-                    },
-                    0,
-                ];
-            },
-        },
-    },
+		code: {
+			toDOM() {
+				return ["code", 0];
+			},
+		},
+
+		link: {
+			attrs: {
+				href: {},
+				title: { default: null },
+			},
+			inclusive: false,
+			toDOM(mark) {
+				return [
+					"a",
+					{
+						href: mark.attrs.href,
+						title: mark.attrs.title,
+					},
+					0,
+				];
+			},
+		},
+	},
 });

--- a/apps/worker/github/comment.ts
+++ b/apps/worker/github/comment.ts
@@ -17,6 +17,10 @@ export type PostSayrCommentContext = {
 	repo: string;
 	repo_private: boolean;
 	number: number;
+	// The linked githubIssue/githubPullRequest row's internal repositoryId —
+	// callers already have this from the lookup that found the task in the
+	// first place, so it's threaded through rather than re-derived here.
+	repositoryId: string;
 
 	// Attribution
 	authorLogin?: string;
@@ -63,13 +67,10 @@ export async function postSayrComment(ctx: PostSayrCommentContext, body: string)
 			// Look up linked Sayr user from GitHub account
 			const linkedUserId = await findLinkedSayrUser(ctx.authorGithubId);
 
-			const repository = await db.query.githubRepository.findFirst({
-				where: (r) => and(eq(r.organizationId, ctx.orgId), eq(r.repoName, `${ctx.owner}/${ctx.repo}`)),
+			const prosekitContent = await markdownToProsekitJSON(body, {
+				organizationId: ctx.orgId,
+				repositoryId: ctx.repositoryId,
 			});
-			const prosekitContent = await markdownToProsekitJSON(
-				body,
-				repository ? { organizationId: ctx.orgId, repositoryId: repository.id } : undefined
-			);
 			const issueUrl = ctx.pull_request
 				? `https://github.com/${ctx.owner}/${ctx.repo}/pull/${ctx.number}`
 				: `https://github.com/${ctx.owner}/${ctx.repo}/issues/${ctx.number}`;

--- a/apps/worker/github/comment.ts
+++ b/apps/worker/github/comment.ts
@@ -31,7 +31,7 @@ export type PostSayrCommentContext = {
  * Attempts to find a Sayr user linked to the given GitHub numeric ID.
  * Returns the Sayr user ID if found, otherwise undefined.
  */
-async function findLinkedSayrUser(githubId?: number): Promise<string | undefined> {
+export async function findLinkedSayrUser(githubId?: number): Promise<string | undefined> {
 	if (!githubId) return undefined;
 
 	const linked = await db.query.account.findFirst({

--- a/apps/worker/github/comment.ts
+++ b/apps/worker/github/comment.ts
@@ -1,31 +1,30 @@
 import { createTraceAsync } from "@repo/opentelemetry/trace";
 import { and, eq } from "drizzle-orm";
 import { db } from "@repo/database";
+import type { JobGroups } from "@repo/queue";
 import { markdownToProsekitJSON } from "./markdownToProsekit";
 
 const API_URL =
-    process.env.APP_ENV === "development"
-        ? "http://localhost:5468/api/internal"
-        : "http://backend:5468/api/internal";
+	process.env.APP_ENV === "development" ? "http://localhost:5468/api/internal" : "http://backend:5468/api/internal";
 
 export type PostSayrCommentContext = {
-    // Sayr task
-    taskKey: number;
-    orgId: string;
+	// Sayr task
+	taskKey: number;
+	orgId: string;
 
-    // GitHub source
-    owner: string;
-    repo: string;
-    repo_private: boolean;
-    number: number;
+	// GitHub source
+	owner: string;
+	repo: string;
+	repo_private: boolean;
+	number: number;
 
-    // Attribution
-    authorLogin?: string;
-    authorGithubId?: number;
+	// Attribution
+	authorLogin?: string;
+	authorGithubId?: number;
 
-    // External IDs
-    externalCommentId?: number;
-    pull_request?: boolean;
+	// External IDs
+	externalCommentId?: number;
+	pull_request?: boolean;
 };
 
 /**
@@ -33,106 +32,203 @@ export type PostSayrCommentContext = {
  * Returns the Sayr user ID if found, otherwise undefined.
  */
 async function findLinkedSayrUser(githubId?: number): Promise<string | undefined> {
-    if (!githubId) return undefined;
+	if (!githubId) return undefined;
 
-    const linked = await db.query.account.findFirst({
-        where: (a) =>
-            and(
-                eq(a.providerId, "github"),
-                eq(a.accountId, String(githubId))
-            ),
-        columns: { userId: true },
-    });
+	const linked = await db.query.account.findFirst({
+		where: (a) => and(eq(a.providerId, "github"), eq(a.accountId, String(githubId))),
+		columns: { userId: true },
+	});
 
-    return linked?.userId;
+	return linked?.userId;
 }
 
-export async function postSayrComment(
-    ctx: PostSayrCommentContext,
-    body: string
-) {
-    const traceAsync = createTraceAsync();
+export async function postSayrComment(ctx: PostSayrCommentContext, body: string) {
+	const traceAsync = createTraceAsync();
 
-    return traceAsync(
-        "sayr.comment.create",
-        async () => {
-            if (!body.trim()) {
-                return;
-            }
+	return traceAsync(
+		"sayr.comment.create",
+		async () => {
+			if (!body.trim()) {
+				return;
+			}
 
-            const task = await db.query.task.findFirst({
-                where: (t) =>
-                    and(
-                        eq(t.organizationId, ctx.orgId),
-                        eq(t.shortId, ctx.taskKey)
-                    ),
-            });
+			const task = await db.query.task.findFirst({
+				where: (t) => and(eq(t.organizationId, ctx.orgId), eq(t.shortId, ctx.taskKey)),
+			});
 
-            if (!task) {
-                return;
-            }
+			if (!task) {
+				return;
+			}
 
-            // Look up linked Sayr user from GitHub account
-            const linkedUserId = await findLinkedSayrUser(ctx.authorGithubId);
+			// Look up linked Sayr user from GitHub account
+			const linkedUserId = await findLinkedSayrUser(ctx.authorGithubId);
 
-            const prosekitContent = markdownToProsekitJSON(body);
-            const issueUrl = ctx.pull_request ? `https://github.com/${ctx.owner}/${ctx.repo}/pull/${ctx.number}` : `https://github.com/${ctx.owner}/${ctx.repo}/issues/${ctx.number}`;
-            const commentUrl =
-                ctx.externalCommentId
-                    ? `${issueUrl}#issuecomment-${ctx.externalCommentId}`
-                    : undefined;
-            const res = await fetch(
-                `${API_URL}/v1/admin/organization/task/create-comment`,
-                {
-                    method: "POST",
-                    headers: {
-                        "Content-Type": "application/json",
-                        cookie: `sayr_internal=${process.env.INTERNAL_SECRET};`,
-                        "user-agent": "Sayr-Worker/1.0",
-                        "x-internal-secret": process.env.INTERNAL_SECRET!,
-                        "x-internal-service": "sayr-worker",
-                        "x-internal-timestamp": new Date().toISOString(),
-                    },
-                    body: JSON.stringify({
-                        org_id: ctx.orgId,
-                        task_id: task.id,
-                        content: prosekitContent,
-                        source: "github",
-                        externalAuthorLogin: ctx.authorLogin,
-                        externalAuthorUrl: `https://github.com/${ctx.authorLogin}`,
-                        ...(linkedUserId && { createdBy: linkedUserId }),
-                        // Visibility mirrors repo privacy
-                        visibility: ctx.repo_private
-                            ? "internal"
-                            : "public",
-                        // External linkage
-                        externalIssueNumber: ctx.number,
-                        externalCommentId:
-                            ctx.externalCommentId,
-                        externalCommentUrl: commentUrl,
-                        pullRequest: ctx.pull_request || false,
-                    }),
-                }
-            );
+			const prosekitContent = markdownToProsekitJSON(body);
+			const issueUrl = ctx.pull_request
+				? `https://github.com/${ctx.owner}/${ctx.repo}/pull/${ctx.number}`
+				: `https://github.com/${ctx.owner}/${ctx.repo}/issues/${ctx.number}`;
+			const commentUrl = ctx.externalCommentId ? `${issueUrl}#issuecomment-${ctx.externalCommentId}` : undefined;
+			const res = await fetch(`${API_URL}/v1/admin/organization/task/create-comment`, {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					cookie: `sayr_internal=${process.env.INTERNAL_SECRET};`,
+					"user-agent": "Sayr-Worker/1.0",
+					"x-internal-secret": process.env.INTERNAL_SECRET!,
+					"x-internal-service": "sayr-worker",
+					"x-internal-timestamp": new Date().toISOString(),
+				},
+				body: JSON.stringify({
+					org_id: ctx.orgId,
+					task_id: task.id,
+					content: prosekitContent,
+					source: "github",
+					externalAuthorLogin: ctx.authorLogin,
+					externalAuthorUrl: `https://github.com/${ctx.authorLogin}`,
+					...(linkedUserId && { createdBy: linkedUserId }),
+					// Visibility mirrors repo privacy
+					visibility: ctx.repo_private ? "internal" : "public",
+					// External linkage
+					externalIssueNumber: ctx.number,
+					externalCommentId: ctx.externalCommentId,
+					externalCommentUrl: commentUrl,
+					pullRequest: ctx.pull_request || false,
+				}),
+			});
 
-            if (!res.ok) {
-                const msg = `Failed to post comment to task ${ctx.taskKey}: ${res.statusText}`;
-                console.error(msg);
-                return msg;
-            }
+			if (!res.ok) {
+				const msg = `Failed to post comment to task ${ctx.taskKey}: ${res.statusText}`;
+				console.error(msg);
+				return msg;
+			}
 
-            console.log(`Comment posted to task ${ctx.taskKey}${linkedUserId ? ` (linked to Sayr user ${linkedUserId})` : ""}.`);
-            return `Comment posted to task ${ctx.taskKey}.`;
-        },
-        {
-            description: "Post Sayr comment from GitHub",
-            data: {
-                orgId: ctx.orgId,
-                taskKey: ctx.taskKey,
-                repo: ctx.repo,
-                number: ctx.number,
-                author: ctx.authorLogin,
-            },
-        }
-    );
+			console.log(
+				`Comment posted to task ${ctx.taskKey}${linkedUserId ? ` (linked to Sayr user ${linkedUserId})` : ""}.`
+			);
+			return `Comment posted to task ${ctx.taskKey}.`;
+		},
+		{
+			description: "Post Sayr comment from GitHub",
+			data: {
+				orgId: ctx.orgId,
+				taskKey: ctx.taskKey,
+				repo: ctx.repo,
+				number: ctx.number,
+				author: ctx.authorLogin,
+			},
+		}
+	);
+}
+
+/**
+ * Inbound sync: a GitHub comment (previously mirrored into Sayr on
+ * creation) was edited upstream. Finds the matching `taskComment` by its
+ * `externalCommentId` and pushes the new body through the same
+ * `PUT /edit-comment` route the frontend uses, so the free history-snapshot
+ * behavior already in that route applies here too.
+ */
+export async function handleCommentEdited(job: JobGroups["github"] & { type: "issue_comment_edited" }) {
+	const traceAsync = createTraceAsync();
+	const { organizationId, commentId, commentBody } = job.payload;
+
+	if (!organizationId) return;
+
+	return traceAsync(
+		"github.comment.edited.process",
+		async () => {
+			const comment = await db.query.taskComment.findFirst({
+				where: (t) =>
+					and(eq(t.organizationId, organizationId), eq(t.source, "github"), eq(t.externalCommentId, commentId)),
+			});
+
+			if (!comment) return;
+
+			const content = markdownToProsekitJSON(commentBody);
+
+			const res = await fetch(`${API_URL}/v1/admin/organization/task/edit-comment`, {
+				method: "PUT",
+				headers: {
+					"Content-Type": "application/json",
+					cookie: `sayr_internal=${process.env.INTERNAL_SECRET};`,
+					"user-agent": "Sayr-Worker/1.0",
+					"x-internal-secret": process.env.INTERNAL_SECRET!,
+					"x-internal-service": "sayr-worker",
+					"x-internal-timestamp": new Date().toISOString(),
+				},
+				body: JSON.stringify({
+					org_id: organizationId,
+					comment_id: comment.id,
+					content,
+				}),
+			});
+
+			if (!res.ok) {
+				console.error(
+					`❌ Failed to sync edited GitHub comment ${commentId} to comment ${comment.id}: ${res.statusText}`
+				);
+				return;
+			}
+
+			console.log(`Comment ${comment.id} updated from GitHub comment ${commentId}.`);
+		},
+		{
+			description: "Syncing edited GitHub comment into linked Sayr comment",
+			data: { orgId: organizationId, commentId },
+		}
+	);
+}
+
+/**
+ * Inbound sync: a GitHub comment (previously mirrored into Sayr on
+ * creation) was deleted upstream. Per the two-way-sync decision, this is a
+ * hard delete on the Sayr side (cascades history/reactions via the existing
+ * `DELETE /delete-comment` route).
+ */
+export async function handleCommentDeleted(job: JobGroups["github"] & { type: "issue_comment_deleted" }) {
+	const traceAsync = createTraceAsync();
+	const { organizationId, commentId } = job.payload;
+
+	if (!organizationId) return;
+
+	return traceAsync(
+		"github.comment.deleted.process",
+		async () => {
+			const comment = await db.query.taskComment.findFirst({
+				where: (t) =>
+					and(eq(t.organizationId, organizationId), eq(t.source, "github"), eq(t.externalCommentId, commentId)),
+			});
+
+			if (!comment) return;
+
+			const res = await fetch(`${API_URL}/v1/admin/organization/task/delete-comment`, {
+				method: "DELETE",
+				headers: {
+					"Content-Type": "application/json",
+					cookie: `sayr_internal=${process.env.INTERNAL_SECRET};`,
+					"user-agent": "Sayr-Worker/1.0",
+					"x-internal-secret": process.env.INTERNAL_SECRET!,
+					"x-internal-service": "sayr-worker",
+					"x-internal-timestamp": new Date().toISOString(),
+				},
+				body: JSON.stringify({
+					org_id: organizationId,
+					task_id: comment.taskId,
+					comment_id: comment.id,
+				}),
+			});
+
+			if (!res.ok) {
+				console.error(
+					`❌ Failed to sync deleted GitHub comment ${commentId} (Sayr comment ${comment.id}): ${res.statusText}`
+				);
+				return;
+			}
+
+			console.log(`Comment ${comment.id} deleted from GitHub comment ${commentId}.`);
+		},
+		{
+			description: "Syncing deleted GitHub comment into linked Sayr comment",
+			data: { orgId: organizationId, commentId },
+		}
+	);
 }

--- a/apps/worker/github/comment.ts
+++ b/apps/worker/github/comment.ts
@@ -1,6 +1,6 @@
 import { createTraceAsync } from "@repo/opentelemetry/trace";
 import { and, eq } from "drizzle-orm";
-import { db } from "@repo/database";
+import { db, schema } from "@repo/database";
 import type { JobGroups } from "@repo/queue";
 import { markdownToProsekitJSON } from "./markdownToProsekit";
 
@@ -63,7 +63,13 @@ export async function postSayrComment(ctx: PostSayrCommentContext, body: string)
 			// Look up linked Sayr user from GitHub account
 			const linkedUserId = await findLinkedSayrUser(ctx.authorGithubId);
 
-			const prosekitContent = markdownToProsekitJSON(body);
+			const repository = await db.query.githubRepository.findFirst({
+				where: (r) => and(eq(r.organizationId, ctx.orgId), eq(r.repoName, `${ctx.owner}/${ctx.repo}`)),
+			});
+			const prosekitContent = await markdownToProsekitJSON(
+				body,
+				repository ? { organizationId: ctx.orgId, repositoryId: repository.id } : undefined
+			);
 			const issueUrl = ctx.pull_request
 				? `https://github.com/${ctx.owner}/${ctx.repo}/pull/${ctx.number}`
 				: `https://github.com/${ctx.owner}/${ctx.repo}/issues/${ctx.number}`;
@@ -129,7 +135,7 @@ export async function postSayrComment(ctx: PostSayrCommentContext, body: string)
  */
 export async function handleCommentEdited(job: JobGroups["github"] & { type: "issue_comment_edited" }) {
 	const traceAsync = createTraceAsync();
-	const { organizationId, commentId, commentBody } = job.payload;
+	const { organizationId, commentId, commentBody, repoId } = job.payload;
 
 	if (!organizationId) return;
 
@@ -143,7 +149,13 @@ export async function handleCommentEdited(job: JobGroups["github"] & { type: "is
 
 			if (!comment) return;
 
-			const content = markdownToProsekitJSON(commentBody);
+			const repository = await db.query.githubRepository.findFirst({
+				where: eq(schema.githubRepository.repoId, repoId),
+			});
+			const content = await markdownToProsekitJSON(
+				commentBody,
+				repository ? { organizationId, repositoryId: repository.id } : undefined
+			);
 
 			const res = await fetch(`${API_URL}/v1/admin/organization/task/edit-comment`, {
 				method: "PUT",

--- a/apps/worker/github/index.ts
+++ b/apps/worker/github/index.ts
@@ -92,7 +92,7 @@ export async function handleSayrKeywordParse(job: JobGroups["github"] & { type: 
 		);
 	}
 	if (!summaryLines.length) {
-		await traceAsync("github.comment.skip", async () => { }, {
+		await traceAsync("github.comment.skip", async () => {}, {
 			description: "No actionable Sayr keywords found",
 			data: { repo, number },
 		});
@@ -128,29 +128,14 @@ export async function postGithubComment(ctx: Omit<KeywordContext, "taskKey" | "m
 	});
 }
 
-export async function handleComment(
-	job: JobGroups["github"] & { type: "issue_comment" }
-) {
+export async function handleComment(job: JobGroups["github"] & { type: "issue_comment" }) {
 	const traceAsync = createTraceAsync();
-	const {
-		owner,
-		organizationId,
-		number,
-		repo,
-		commentId,
-		commentBody,
-		user,
-		userId,
-		repo_private
-	} = job.payload;
+	const { owner, organizationId, number, repo, commentId, commentBody, user, userId, repo_private } = job.payload;
 
 	// --------------------
 	// Sanitize content (no uploads)
 	// --------------------
-	const sanitizedBody = commentBody.replace(
-		/<(img|video|iframe|object|embed)[^>]*>/gi,
-		""
-	);
+	const sanitizedBody = commentBody.replace(/<(img|video|iframe|object|embed)[^>]*>/gi, "");
 
 	if (!sanitizedBody.trim()) {
 		return;
@@ -163,11 +148,7 @@ export async function handleComment(
 		"github.issue.link.lookup",
 		() =>
 			db.query.githubIssue.findFirst({
-				where: (gi) =>
-					and(
-						eq(gi.organizationId, organizationId || ""),
-						eq(gi.issueNumber, number)
-					),
+				where: (gi) => and(eq(gi.organizationId, organizationId || ""), eq(gi.issueNumber, number)),
 				with: { task: true },
 			}),
 		{
@@ -181,11 +162,7 @@ export async function handleComment(
 			"github.pull_request.lookup",
 			() =>
 				db.query.githubPullRequest.findFirst({
-					where: (gi) =>
-						and(
-							eq(gi.organizationId, organizationId || ""),
-							eq(gi.prNumber, number)
-						),
+					where: (gi) => and(eq(gi.organizationId, organizationId || ""), eq(gi.prNumber, number)),
 					with: { task: true },
 				}),
 			{
@@ -211,6 +188,7 @@ export async function handleComment(
 						repo_private,
 						externalCommentId: commentId,
 						pull_request: true,
+						repositoryId: githubPullRequest.repositoryId,
 					},
 					sanitizedBody
 				),
@@ -243,7 +221,8 @@ export async function handleComment(
 					authorLogin: user,
 					authorGithubId: userId,
 					repo_private,
-					externalCommentId: commentId
+					externalCommentId: commentId,
+					repositoryId: githubIssue.repositoryId,
 				},
 				sanitizedBody
 			),

--- a/apps/worker/github/issue.ts
+++ b/apps/worker/github/issue.ts
@@ -48,7 +48,10 @@ export async function handleIssueEdited(job: JobGroups["github"] & { type: "issu
 			if (!issue?.task) return;
 			if (issue.task.visible !== "public") return;
 
-			const description = markdownToProsekitJSON(body);
+			const description = await markdownToProsekitJSON(body, {
+				organizationId,
+				repositoryId: repository.id,
+			});
 
 			const res = await fetch(`${API_URL}/v1/admin/organization/task/update`, {
 				method: "PATCH",
@@ -118,7 +121,14 @@ export async function handleIssueOpened(job: JobGroups["github"] & { type: "issu
 			// `externalAuthorLogin`-style columns the way `taskComment` does.
 			const linkedUserId = await findLinkedSayrUser(userId);
 			const markdown = linkedUserId ? body : `_Originally opened by @${job.payload.user} on GitHub_\n\n${body}`;
-			const description = markdownToProsekitJSON(markdown);
+
+			const repository = await db.query.githubRepository.findFirst({
+				where: eq(schema.githubRepository.repoId, repoId),
+			});
+			const description = await markdownToProsekitJSON(
+				markdown,
+				repository ? { organizationId, repositoryId: repository.id } : undefined
+			);
 
 			const res = await fetch(`${API_URL}/v1/admin/organization/task/create`, {
 				method: "POST",

--- a/apps/worker/github/issue.ts
+++ b/apps/worker/github/issue.ts
@@ -1,0 +1,88 @@
+import { db, schema } from "@repo/database";
+import { createTraceAsync } from "@repo/opentelemetry/trace";
+import type { JobGroups } from "@repo/queue";
+import { and, eq } from "drizzle-orm";
+import { markdownToProsekitJSON } from "./markdownToProsekit";
+
+const API_URL =
+	process.env.APP_ENV === "development" ? "http://localhost:5468/api/internal" : "http://backend:5468/api/internal";
+
+/**
+ * Inbound sync: a GitHub issue body/title was edited, push the change into
+ * the linked Sayr task's title/description — but only when that task is
+ * public (private tasks/repos are never touched by this pipeline).
+ *
+ * Uses `skipGithubSync: true` on the internal update call so this
+ * inbound-triggered save doesn't immediately queue a redundant outbound
+ * push back to GitHub from the description-sync cron sweep.
+ */
+export async function handleIssueEdited(job: JobGroups["github"] & { type: "issue_edited" }) {
+	const traceAsync = createTraceAsync();
+	const { organizationId, repoId, repo_private, number, title, body } = job.payload;
+
+	if (!organizationId) return;
+	// Repo-level privacy is already known from the webhook payload — but the
+	// authoritative check happens live via the GitHub API in the cron sweep;
+	// here we can fast-skip on the payload's own flag to avoid unnecessary work.
+	if (repo_private) return;
+
+	await traceAsync(
+		"github.issue_edited.process",
+		async () => {
+			const repository = await db.query.githubRepository.findFirst({
+				where: eq(schema.githubRepository.repoId, repoId),
+			});
+
+			if (!repository) return;
+
+			const issue = await db.query.githubIssue.findFirst({
+				where: (t) =>
+					and(eq(t.organizationId, organizationId), eq(t.repositoryId, repository.id), eq(t.issueNumber, number)),
+				with: { task: true },
+			});
+
+			if (!issue?.task) return;
+			if (issue.task.visible !== "public") return;
+
+			const description = markdownToProsekitJSON(body);
+
+			const res = await fetch(`${API_URL}/v1/admin/organization/task/update`, {
+				method: "PATCH",
+				headers: {
+					"Content-Type": "application/json",
+					cookie: `sayr_internal=${process.env.INTERNAL_SECRET};`,
+					"user-agent": "Sayr-Worker/1.0",
+					"x-internal-secret": process.env.INTERNAL_SECRET!,
+					"x-internal-service": "sayr-worker",
+					"x-internal-timestamp": new Date().toISOString(),
+				},
+				body: JSON.stringify({
+					org_id: organizationId,
+					task_id: issue.task.id,
+					title,
+					description,
+					skipGithubSync: true,
+				}),
+			});
+
+			if (!res.ok) {
+				console.error(
+					`❌ Failed to sync edited GitHub issue #${number} into task ${issue.task.id}: ${res.statusText}`
+				);
+				return;
+			}
+
+			// Bump `updatedAt` so the description-sync cron sweep (which compares
+			// `task.updatedAt > githubIssue.updatedAt`) doesn't treat this
+			// inbound-applied change as "task changed since last GitHub sync"
+			// and immediately push the same content straight back out.
+			await db.update(schema.githubIssue).set({ updatedAt: new Date() }).where(eq(schema.githubIssue.id, issue.id));
+
+			console.log(`✅ Synced edited GitHub issue #${number} into task ${issue.task.id}.`);
+		},
+		{
+			description: "Syncing edited GitHub issue title/body into the linked Sayr task",
+			data: { organizationId, repoId, number },
+		}
+	);
+}

--- a/apps/worker/github/issue.ts
+++ b/apps/worker/github/issue.ts
@@ -1,6 +1,9 @@
+import { Octokit } from "@octokit/rest";
 import { db, schema } from "@repo/database";
 import { createTraceAsync } from "@repo/opentelemetry/trace";
 import type { JobGroups } from "@repo/queue";
+import { formatTaskKey } from "@repo/util";
+import { getInstallationToken } from "@repo/util/github/auth";
 import { and, eq } from "drizzle-orm";
 import { findLinkedSayrUser } from "./comment";
 import { markdownToProsekitJSON } from "./markdownToProsekit";
@@ -133,6 +136,7 @@ export async function handleIssueOpened(job: JobGroups["github"] & { type: "issu
 					description,
 					category: categoryId ?? undefined,
 					visible: "public",
+					status: "backlog",
 					skipGithubSync: true,
 					createdBy: linkedUserId,
 				}),
@@ -143,7 +147,7 @@ export async function handleIssueOpened(job: JobGroups["github"] & { type: "issu
 				return;
 			}
 
-			const created = (await res.json()) as { success: boolean; data?: { id: string } };
+			const created = (await res.json()) as { success: boolean; data?: { id: string; shortId: number } };
 			if (!created.success || !created.data?.id) {
 				console.error(`❌ Task creation for GitHub issue #${number} returned no task id.`);
 				return;
@@ -176,6 +180,30 @@ export async function handleIssueOpened(job: JobGroups["github"] & { type: "issu
 			}
 
 			console.log(`✅ Created Sayr task ${created.data.id} from GitHub issue #${number}.`);
+
+			// Announce the new task back on the issue, mirroring the ack comment
+			// keyword-triggered actions already post (postGithubComment). Never
+			// fatal — the task's already created and linked either way.
+			try {
+				const org = await db.query.organization.findFirst({
+					where: eq(schema.organization.id, organizationId),
+				});
+				if (org) {
+					const sayrTaskUrl = `https://${org.slug}.${process.env.VITE_ROOT_DOMAIN}/${created.data.shortId}`;
+					const taskKey = formatTaskKey(org.shortId, created.data.shortId);
+					const token = await getInstallationToken(job.payload.installationId);
+					const octokit = new Octokit({ auth: token });
+
+					await octokit.issues.createComment({
+						owner,
+						repo,
+						issue_number: number,
+						body: `✅ Created Sayr task **${taskKey}**: ${sayrTaskUrl}`,
+					});
+				}
+			} catch (err) {
+				console.error(`❌ Failed to post task-created acknowledgment on GitHub issue #${number}:`, err);
+			}
 		},
 		{
 			description: "Creating a Sayr task from a newly opened GitHub issue",

--- a/apps/worker/github/issue.ts
+++ b/apps/worker/github/issue.ts
@@ -2,6 +2,7 @@ import { db, schema } from "@repo/database";
 import { createTraceAsync } from "@repo/opentelemetry/trace";
 import type { JobGroups } from "@repo/queue";
 import { and, eq } from "drizzle-orm";
+import { findLinkedSayrUser } from "./comment";
 import { markdownToProsekitJSON } from "./markdownToProsekit";
 
 const API_URL =
@@ -82,6 +83,102 @@ export async function handleIssueEdited(job: JobGroups["github"] & { type: "issu
 		},
 		{
 			description: "Syncing edited GitHub issue title/body into the linked Sayr task",
+			data: { organizationId, repoId, number },
+		}
+	);
+}
+
+/**
+ * Inbound sync: a brand-new GitHub issue was opened with no Sayr keyword
+ * referencing an existing task (that case is handled separately by
+ * `sayr_keyword_parse` / `handleLinkKeyword`) — create a new task for it and
+ * link the two, mirroring the outbound task→issue creation this pipeline
+ * already does in reverse.
+ *
+ * Uses `skipGithubSync: true` on the internal create call, same reasoning as
+ * `handleIssueEdited`: without it, creating the task would immediately try
+ * to open a *second*, duplicate GitHub issue for it.
+ */
+export async function handleIssueOpened(job: JobGroups["github"] & { type: "issue_opened" }) {
+	const traceAsync = createTraceAsync();
+	const { organizationId, categoryId, repoId, repo_private, owner, repo, number, title, body, userId } = job.payload;
+
+	if (!organizationId) return;
+	if (repo_private) return;
+
+	await traceAsync(
+		"github.issue_opened.process",
+		async () => {
+			// Attribute the task to the issue's author if they've linked their
+			// GitHub account to Sayr; otherwise fall back to a text note, the
+			// same shape as the comment-sync bot fallback — `task` has no
+			// `externalAuthorLogin`-style columns the way `taskComment` does.
+			const linkedUserId = await findLinkedSayrUser(userId);
+			const markdown = linkedUserId ? body : `_Originally opened by @${job.payload.user} on GitHub_\n\n${body}`;
+			const description = markdownToProsekitJSON(markdown);
+
+			const res = await fetch(`${API_URL}/v1/admin/organization/task/create`, {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					cookie: `sayr_internal=${process.env.INTERNAL_SECRET};`,
+					"user-agent": "Sayr-Worker/1.0",
+					"x-internal-secret": process.env.INTERNAL_SECRET!,
+					"x-internal-service": "sayr-worker",
+					"x-internal-timestamp": new Date().toISOString(),
+				},
+				body: JSON.stringify({
+					org_id: organizationId,
+					title,
+					description,
+					category: categoryId ?? undefined,
+					visible: "public",
+					skipGithubSync: true,
+					createdBy: linkedUserId,
+				}),
+			});
+
+			if (!res.ok) {
+				console.error(`❌ Failed to create Sayr task for GitHub issue #${number}: ${res.statusText}`);
+				return;
+			}
+
+			const created = (await res.json()) as { success: boolean; data?: { id: string } };
+			if (!created.success || !created.data?.id) {
+				console.error(`❌ Task creation for GitHub issue #${number} returned no task id.`);
+				return;
+			}
+
+			const linkRes = await fetch(`${API_URL}/v1/admin/organization/task/github-link`, {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					cookie: `sayr_internal=${process.env.INTERNAL_SECRET};`,
+					"user-agent": "Sayr-Worker/1.0",
+					"x-internal-secret": process.env.INTERNAL_SECRET!,
+					"x-internal-service": "sayr-worker",
+					"x-internal-timestamp": new Date().toISOString(),
+				},
+				body: JSON.stringify({
+					org_id: organizationId,
+					task_id: created.data.id,
+					repo_id: repoId,
+					issue_number: number,
+					issue_url: `https://github.com/${owner}/${repo}/issues/${number}`,
+				}),
+			});
+
+			if (!linkRes.ok) {
+				console.error(
+					`❌ Created task ${created.data.id} for GitHub issue #${number} but failed to link it: ${linkRes.statusText}`
+				);
+				return;
+			}
+
+			console.log(`✅ Created Sayr task ${created.data.id} from GitHub issue #${number}.`);
+		},
+		{
+			description: "Creating a Sayr task from a newly opened GitHub issue",
 			data: { organizationId, repoId, number },
 		}
 	);

--- a/apps/worker/github/markdownToProsekit.ts
+++ b/apps/worker/github/markdownToProsekit.ts
@@ -2,6 +2,9 @@
 import MarkdownIt from "markdown-it";
 import { MarkdownParser } from "prosemirror-markdown";
 import type { schema } from "@repo/database";
+import { db } from "@repo/database";
+import { formatTaskKey } from "@repo/util";
+import { and, eq, inArray } from "drizzle-orm";
 import { basicGithubSchema } from "./basicGithubSchema";
 
 /**
@@ -11,99 +14,236 @@ import { basicGithubSchema } from "./basicGithubSchema";
  * - Text-only, safe
  */
 const md = new MarkdownIt({
-    html: false, // 🚫 disable HTML entirely
-    linkify: true,
-    breaks: true,
+	html: false, // 🚫 disable HTML entirely
+	linkify: true,
+	breaks: true,
 });
 /**
  * Markdown → ProseKit (ProseMirror) parser
  */
-const prosekitMarkdownParser = new MarkdownParser(
-    basicGithubSchema,
-    md,
-    {
-        // --------------------
-        // Block nodes
-        // --------------------
-        paragraph: { block: "paragraph" },
-        blockquote: { block: "blockquote" },
+const prosekitMarkdownParser = new MarkdownParser(basicGithubSchema, md, {
+	// --------------------
+	// Block nodes
+	// --------------------
+	paragraph: { block: "paragraph" },
+	blockquote: { block: "blockquote" },
 
-        heading: {
-            block: "heading",
-            getAttrs: (tok) => ({
-                level: Number(tok.tag.slice(1)),
-            }),
-        },
+	heading: {
+		block: "heading",
+		getAttrs: (tok) => ({
+			level: Number(tok.tag.slice(1)),
+		}),
+	},
 
-        bullet_list: { block: "bulletList" },
+	bullet_list: { block: "bulletList" },
 
-        ordered_list: {
-            block: "orderedList",
-            getAttrs: (tok) => ({
-                start: tok.attrGet("start")
-                    ? Number(tok.attrGet("start"))
-                    : 1,
-            }),
-        },
+	ordered_list: {
+		block: "orderedList",
+		getAttrs: (tok) => ({
+			start: tok.attrGet("start") ? Number(tok.attrGet("start")) : 1,
+		}),
+	},
 
-        list_item: { block: "listItem" },
+	list_item: { block: "listItem" },
 
-        fence: {
-            block: "codeBlock",
-            getAttrs: (tok) => ({
-                language: tok.info || null,
-            }),
-        },
+	fence: {
+		block: "codeBlock",
+		getAttrs: (tok) => ({
+			language: tok.info || null,
+		}),
+	},
 
-        code_block: {
-            block: "codeBlock",
-            getAttrs: (tok) => ({
-                language: tok.info || null,
-            }),
-        },
+	code_block: {
+		block: "codeBlock",
+		getAttrs: (tok) => ({
+			language: tok.info || null,
+		}),
+	},
 
-        hr: { node: "horizontalRule" },
-        hardbreak: { node: "hardBreak" },
+	hr: { node: "horizontalRule" },
+	hardbreak: { node: "hardBreak" },
 
-        // --------------------
-        // Marks
-        // --------------------
-        em: { mark: "italic" },
-        strong: { mark: "bold" },
-        s: { mark: "strike" },
-        code_inline: { mark: "code" },
+	// --------------------
+	// Marks
+	// --------------------
+	em: { mark: "italic" },
+	strong: { mark: "bold" },
+	s: { mark: "strike" },
+	code_inline: { mark: "code" },
 
-        link: {
-            mark: "link",
-            getAttrs: (tok) => ({
-                href: tok.attrGet("href"),
-                title: tok.attrGet("title"),
-            }),
-        },
-    }
-);
+	link: {
+		mark: "link",
+		getAttrs: (tok) => ({
+			href: tok.attrGet("href"),
+			title: tok.attrGet("title"),
+		}),
+	},
+});
 function stripGithubImages(markdown: string): string {
-    return markdown.replace(
-        /<img\b[^>]*>/gi,
-        ""
-    );
+	return markdown.replace(/<img\b[^>]*>/gi, "");
 }
-/**
- * Convert Markdown → ProseKit JSON
- */
-export function markdownToProsekitJSON(
-    markdown: string
-): schema.NodeJSON {
-    try {
-        const sanitized = stripGithubImages(markdown);
 
-        const doc = prosekitMarkdownParser.parse(sanitized);
-        return doc.toJSON();
-    } catch (error) {
-        console.error("Markdown → ProseKit conversion failed:", error);
-        return {
-            type: "doc",
-            content: [],
-        };
-    }
+/**
+ * Matches a bare GitHub issue cross-reference like `#10` — GitHub's own
+ * autolinking of these is a backend behavior applied to rendered HTML, not
+ * real markdown syntax, so a generic parser has no reason to treat it as
+ * anything but plain text. Requires the `#` to be preceded by start-of-text,
+ * whitespace, or an opening paren (so `word#10` and hex-ish tokens don't
+ * match), and the digits to end on a word boundary (so `#10.`/`#10,` match
+ * but `#10abc` doesn't).
+ */
+const ISSUE_REFERENCE_PATTERN = /(^|[\s(])#(\d+)\b/g;
+
+type MentionResolutionContext = {
+	organizationId: string;
+	repositoryId: string;
+};
+
+/**
+ * Finds every `#N` reference across the doc, batch-resolves them against
+ * `githubIssue` (only issue numbers already linked to a Sayr task resolve —
+ * everything else is left as plain text), then splices real `mention` nodes
+ * in wherever a match resolved. Two passes: collect first (no DB calls
+ * inside the tree walk), then a synchronous splice using the resolved map.
+ */
+async function resolveGithubIssueReferences(
+	doc: schema.NodeJSON,
+	context: MentionResolutionContext
+): Promise<schema.NodeJSON> {
+	const referencedNumbers = new Set<number>();
+	collectIssueNumbers(doc, referencedNumbers);
+	if (referencedNumbers.size === 0) return doc;
+
+	const linked = await db.query.githubIssue.findMany({
+		where: (gi) =>
+			and(
+				eq(gi.organizationId, context.organizationId),
+				eq(gi.repositoryId, context.repositoryId),
+				inArray(gi.issueNumber, [...referencedNumbers])
+			),
+		with: { task: { columns: { id: true, shortId: true } } },
+	});
+
+	const org = linked.length
+		? await db.query.organization.findFirst({
+				where: (o) => eq(o.id, context.organizationId),
+				columns: { shortId: true },
+			})
+		: null;
+	if (!org) return doc;
+
+	const resolved = new Map<number, { id: string; value: string }>();
+	for (const issue of linked) {
+		if (!issue.task) continue;
+		resolved.set(issue.issueNumber, {
+			id: issue.task.id,
+			value: formatTaskKey(org.shortId, issue.task.shortId),
+		});
+	}
+	if (resolved.size === 0) return doc;
+
+	return spliceMentions(doc, resolved) as schema.NodeJSON;
+}
+
+function collectIssueNumbers(node: unknown, into: Set<number>): void {
+	if (!node || typeof node !== "object") return;
+	const n = node as { type?: string; text?: string; content?: unknown[] };
+
+	if (n.type === "text" && typeof n.text === "string") {
+		for (const match of n.text.matchAll(ISSUE_REFERENCE_PATTERN)) {
+			const num = Number(match[2]);
+			if (!Number.isNaN(num)) into.add(num);
+		}
+		return;
+	}
+
+	if (Array.isArray(n.content)) {
+		for (const child of n.content) collectIssueNumbers(child, into);
+	}
+}
+
+function spliceMentions(node: unknown, resolved: Map<number, { id: string; value: string }>): unknown {
+	if (!node || typeof node !== "object") return node;
+	const n = node as { type?: string; text?: string; marks?: unknown[]; content?: unknown[] };
+
+	// Never splice inside inline code or code blocks — a `#10` there is
+	// source/literal text, not a reference.
+	const hasCodeMark = Array.isArray(n.marks) && n.marks.some((m) => (m as { type?: string })?.type === "code");
+	if (n.type === "text" && typeof n.text === "string" && !hasCodeMark && n.text.includes("#")) {
+		return splitTextNode(n, resolved);
+	}
+
+	if (n.type === "codeBlock") return n;
+
+	if (Array.isArray(n.content)) {
+		return {
+			...n,
+			content: n.content.flatMap((child) => {
+				const result = spliceMentions(child, resolved);
+				return Array.isArray(result) ? result : [result];
+			}),
+		};
+	}
+
+	return n;
+}
+
+function splitTextNode(
+	textNode: { type?: string; text?: string; marks?: unknown[] },
+	resolved: Map<number, { id: string; value: string }>
+): unknown[] {
+	const text = textNode.text ?? "";
+	const out: unknown[] = [];
+	let lastIndex = 0;
+
+	for (const match of text.matchAll(ISSUE_REFERENCE_PATTERN)) {
+		const num = Number(match[2]);
+		const task = resolved.get(num);
+		if (!task || match.index === undefined) continue;
+
+		const leading = match[1] ?? "";
+		const matchStart = match.index + leading.length;
+		const matchEnd = match.index + match[0].length;
+
+		if (matchStart > lastIndex) {
+			out.push({ ...textNode, text: text.slice(lastIndex, matchStart) });
+		}
+		out.push({
+			type: "mention",
+			attrs: { id: task.id, value: task.value, kind: "task" },
+		});
+		lastIndex = matchEnd;
+	}
+
+	if (lastIndex < text.length) {
+		out.push({ ...textNode, text: text.slice(lastIndex) });
+	}
+
+	return out.length ? out : [textNode];
+}
+
+/**
+ * Convert Markdown → ProseKit JSON. `context`, when provided, additionally
+ * resolves bare `#N` GitHub issue references into real Sayr task mentions
+ * (see resolveGithubIssueReferences) — omit it to skip that step entirely.
+ */
+export async function markdownToProsekitJSON(
+	markdown: string,
+	context?: MentionResolutionContext
+): Promise<schema.NodeJSON> {
+	try {
+		const sanitized = stripGithubImages(markdown);
+
+		const doc = prosekitMarkdownParser.parse(sanitized);
+		const json = doc.toJSON() as schema.NodeJSON;
+
+		if (!context) return json;
+		return await resolveGithubIssueReferences(json, context);
+	} catch (error) {
+		console.error("Markdown → ProseKit conversion failed:", error);
+		return {
+			type: "doc",
+			content: [],
+		};
+	}
 }

--- a/apps/worker/index.ts
+++ b/apps/worker/index.ts
@@ -22,6 +22,7 @@ import {
 import { embedTaskWorker } from "./main/embed-task";
 import { gdprExportWorker } from "./main/gdpr";
 import { prosekitJSONToMarkdown } from "./prosekit/markdown";
+import { resolveMentionLinksForGithub } from "./prosekit/resolveMentions";
 
 /* ============================================================
    Environment
@@ -61,6 +62,7 @@ async function runGithubDescriptionSync() {
 			taskId: schema.task.id,
 			taskTitle: schema.task.title,
 			taskDescription: schema.task.description,
+			organizationId: schema.task.organizationId,
 			repoId: schema.githubRepository.repoId,
 			installationId: schema.githubRepository.installationId,
 		})
@@ -92,7 +94,10 @@ async function runGithubDescriptionSync() {
 
 			const owner = repoInfo.owner.login;
 			const repo = repoInfo.name;
-			const body = candidate.taskDescription ? prosekitJSONToMarkdown(candidate.taskDescription) : "";
+			const resolvedDescription = candidate.taskDescription
+				? await resolveMentionLinksForGithub(candidate.taskDescription, candidate.organizationId)
+				: null;
+			const body = resolvedDescription ? prosekitJSONToMarkdown(resolvedDescription) : "";
 
 			await octokit.request("PATCH /repos/{owner}/{repo}/issues/{issue_number}", {
 				owner,

--- a/apps/worker/index.ts
+++ b/apps/worker/index.ts
@@ -11,7 +11,7 @@ import { insertSnapshots, type SnapshotRow } from "./clickhouse";
 import { handleComment, handleSayrKeywordParse } from "./github";
 import { handleCommentDeleted, handleCommentEdited } from "./github/comment";
 import { handleGithubCommitRef } from "./github/commitRef";
-import { handleIssueEdited } from "./github/issue";
+import { handleIssueEdited, handleIssueOpened } from "./github/issue";
 import {
 	handleGithubBranchDelete,
 	handleGithubBranchLink,
@@ -238,6 +238,9 @@ async function processGithubJob(job: JobGroups["github"]) {
 		case "issue_edited":
 			return handleIssueEdited(job);
 
+		case "issue_opened":
+			return handleIssueOpened(job);
+
 		case "issue_comment_edited":
 			return handleCommentEdited(job);
 
@@ -263,7 +266,9 @@ async function processGithubJob(job: JobGroups["github"]) {
 			return handleGithubBranchDelete(job);
 
 		default:
-			console.warn(`⚠️ Unhandled GitHub job type: ${job.type}`);
+			// The switch above is exhaustive over `GithubJob`, so `job` narrows to
+			// `never` here — cast back just to log the (should-be-impossible) case.
+			console.warn(`⚠️ Unhandled GitHub job type: ${(job as JobGroups["github"]).type}`);
 	}
 }
 

--- a/apps/worker/index.ts
+++ b/apps/worker/index.ts
@@ -1,13 +1,17 @@
+import { Octokit } from "@octokit/rest";
 import { auth, db, schema } from "@repo/database";
 import { isCloud } from "@repo/edition";
 import { initTracing } from "@repo/opentelemetry";
 import { withTraceContext } from "@repo/opentelemetry/trace";
 import { dequeue, type JobGroups } from "@repo/queue";
+import { getInstallationToken } from "@repo/util/github/auth";
 import { CronJob } from "cron";
-import { eq, lt, sql } from "drizzle-orm";
+import { and, eq, gt, lt, sql } from "drizzle-orm";
 import { insertSnapshots, type SnapshotRow } from "./clickhouse";
 import { handleComment, handleSayrKeywordParse } from "./github";
+import { handleCommentDeleted, handleCommentEdited } from "./github/comment";
 import { handleGithubCommitRef } from "./github/commitRef";
+import { handleIssueEdited } from "./github/issue";
 import {
 	handleGithubBranchDelete,
 	handleGithubBranchLink,
@@ -17,6 +21,7 @@ import {
 } from "./github/pullRequest";
 import { embedTaskWorker } from "./main/embed-task";
 import { gdprExportWorker } from "./main/gdpr";
+import { prosekitJSONToMarkdown } from "./prosekit/markdown";
 
 /* ============================================================
    Environment
@@ -38,6 +43,86 @@ process.on("SIGTERM", () => initiateShutdown("SIGTERM"));
 process.on("SIGINT", () => initiateShutdown("SIGINT"));
 
 /* ============================================================
+   GitHub Description Sync Sweep (Main Worker Only)
+   ============================================================
+   Outbound half of SAY-41's two-way sync: public tasks linked to a public
+   GitHub issue get their title/description pushed to GitHub on a batched
+   interval rather than in real time (see plan §4 — decoupled from the
+   per-save debounce on purpose). `task.updatedAt > githubIssue.updatedAt`
+   is a simple "changed since last GitHub push" heuristic reusing the
+   existing `githubIssue.updatedAt` column; an unrelated field change
+   (status/priority/etc) can trigger one redundant-but-harmless PATCH — an
+   accepted trade-off over adding a dedicated dirty-flag column. */
+async function runGithubDescriptionSync() {
+	const candidates = await db
+		.select({
+			issueId: schema.githubIssue.id,
+			issueNumber: schema.githubIssue.issueNumber,
+			taskId: schema.task.id,
+			taskTitle: schema.task.title,
+			taskDescription: schema.task.description,
+			repoId: schema.githubRepository.repoId,
+			installationId: schema.githubRepository.installationId,
+		})
+		.from(schema.githubIssue)
+		.innerJoin(schema.task, eq(schema.githubIssue.taskId, schema.task.id))
+		.innerJoin(schema.githubRepository, eq(schema.githubIssue.repositoryId, schema.githubRepository.id))
+		.where(
+			and(
+				eq(schema.task.visible, "public"),
+				eq(schema.githubRepository.enabled, true),
+				gt(schema.task.updatedAt, schema.githubIssue.updatedAt)
+			)
+		)
+		.limit(50); // cap the batch so one slow tick can't block indefinitely
+
+	for (const candidate of candidates) {
+		try {
+			const token = await getInstallationToken(candidate.installationId);
+			const octokit = new Octokit({ auth: token });
+
+			// Resolve owner/repo AND re-check privacy live — a task's own
+			// visibility isn't enough on its own, the repo's current privacy
+			// has to be gated too, and it can change after the repo was linked.
+			const { data: repoInfo } = await octokit.request("GET /repositories/{repository_id}", {
+				repository_id: candidate.repoId,
+			});
+
+			if (repoInfo.private) continue;
+
+			const owner = repoInfo.owner.login;
+			const repo = repoInfo.name;
+			const body = candidate.taskDescription ? prosekitJSONToMarkdown(candidate.taskDescription) : "";
+
+			await octokit.request("PATCH /repos/{owner}/{repo}/issues/{issue_number}", {
+				owner,
+				repo,
+				issue_number: candidate.issueNumber,
+				...(candidate.taskTitle ? { title: candidate.taskTitle } : {}),
+				body,
+			});
+
+			// Bump updatedAt so this row falls out of the next sweep.
+			await db
+				.update(schema.githubIssue)
+				.set({ updatedAt: new Date() })
+				.where(eq(schema.githubIssue.id, candidate.issueId));
+		} catch (err) {
+			// Non-fatal — a GitHub-side failure on one row must never block the
+			// rest of the batch (or the next tick).
+			console.error(
+				`❌ Failed to sync task ${candidate.taskId} description to GitHub issue #${candidate.issueNumber}:`,
+				err
+			);
+		}
+	}
+
+	if (candidates.length > 0) {
+		console.log(`📤 GitHub description sync: pushed ${candidates.length} task(s) to GitHub.`);
+	}
+}
+
+/* ============================================================
    Cron Jobs (Main Worker Only)
    ============================================================ */
 function initMainCronJobs() {
@@ -55,6 +140,20 @@ function initMainCronJobs() {
 				console.log("🧹 Cleaned expired invites (older than 24h)");
 			} catch (err) {
 				console.error("❌ Cron error deleting invites:", err);
+			}
+		},
+		null,
+		true
+	);
+
+	// Outbound GitHub description sync — batched, roughly every minute (see SAY-41)
+	new CronJob(
+		"* * * * *",
+		async () => {
+			try {
+				await runGithubDescriptionSync();
+			} catch (err) {
+				console.error("❌ Cron error syncing task descriptions to GitHub:", err);
 			}
 		},
 		null,
@@ -135,6 +234,15 @@ async function processGithubJob(job: JobGroups["github"]) {
 
 		case "issue_comment":
 			return handleComment(job);
+
+		case "issue_edited":
+			return handleIssueEdited(job);
+
+		case "issue_comment_edited":
+			return handleCommentEdited(job);
+
+		case "issue_comment_deleted":
+			return handleCommentDeleted(job);
 
 		case "github_commit_ref":
 			return handleGithubCommitRef(job);

--- a/apps/worker/prosekit/markdown.ts
+++ b/apps/worker/prosekit/markdown.ts
@@ -1,0 +1,134 @@
+import type { schema } from "@repo/database";
+import { MarkdownSerializer } from "prosemirror-markdown";
+import { prosekitSchema } from "./schema";
+
+// Mirrors apps/backend/prosekit/markdown.ts verbatim — see schema.ts in this
+// directory for why this is duplicated rather than imported across the
+// app boundary.
+const markdownSerializer = new MarkdownSerializer(
+	{
+		doc: (state, node) => {
+			state.renderContent(node);
+		},
+		paragraph: (state, node) => {
+			state.renderInline(node);
+			state.closeBlock(node);
+		},
+		heading: (state, node) => {
+			state.write(`${"#".repeat(node.attrs.level)} `);
+			state.renderInline(node);
+			state.closeBlock(node);
+		},
+		blockquote: (state, node) => {
+			state.wrapBlock("> ", null, node, () => state.renderContent(node));
+		},
+		codeBlock: (state, node) => {
+			state.write(`\`\`\`${node.attrs.language || ""}\n`);
+			state.text(node.textContent, false);
+			state.ensureNewLine();
+			state.write("```");
+			state.closeBlock(node);
+		},
+		bulletList: (state, node) => {
+			state.renderList(node, "  ", () => "- ");
+		},
+		orderedList: (state, node) => {
+			const start = node.attrs.start || 1;
+			state.renderList(node, "  ", (i) => `${start + i}. `);
+		},
+		listItem: (state, node) => {
+			state.renderContent(node);
+		},
+		horizontalRule: (state, node) => {
+			state.write("---");
+			state.closeBlock(node);
+		},
+		hardBreak: (state) => {
+			state.write("  \n");
+		},
+		image: (state, node) => {
+			const { src, width, height } = node.attrs;
+			const dims = width && height ? ` width="${width}" height="${height}"` : "";
+			state.write(`<img src="${src}"${dims} />`);
+			state.closeBlock(node);
+		},
+		video: (state, node) => {
+			state.write(`<video src="${node.attrs.src}" controls></video>`);
+			state.closeBlock(node);
+		},
+		gif: (state, node) => {
+			const { src, width, height } = node.attrs;
+			const dims = width && height ? ` width="${width}" height="${height}"` : "";
+			state.write(`<img src="${src}"${dims} />`);
+			state.closeBlock(node);
+		},
+		mention: (state, node) => {
+			state.write(node.attrs.value || "");
+		},
+		table: (state, node) => {
+			const rows: string[][] = [];
+
+			node.forEach((row) => {
+				if (row.type.name !== "tableRow") return;
+				const cells: string[] = [];
+				row.forEach((cell) => {
+					cells.push(cell.textContent.replace(/\|/g, "\\|").replace(/\n/g, " "));
+				});
+				rows.push(cells);
+			});
+
+			if (rows.length === 0) return;
+
+			const colCount = rows[0]?.length ?? 0;
+			state.write(`| ${rows[0]?.join(" | ")} |\n`);
+			state.write(`| ${Array(colCount).fill("---").join(" | ")} |\n`);
+
+			for (let i = 1; i < rows.length; i++) {
+				state.write(`| ${rows[i]?.join(" | ")} |\n`);
+			}
+
+			state.closeBlock(node);
+		},
+		tableRow: () => {
+			// Handled by table
+		},
+		tableCell: () => {
+			// Handled by table
+		},
+		tableHeader: () => {
+			// Handled by table
+		},
+		text: (state, node) => {
+			state.text(node.text || "");
+		},
+		list: (state, node) => {
+			const isOrdered = node.attrs.kind === "ordered";
+			const start = node.attrs.start || 1;
+			state.renderList(node, "  ", (i) => (isOrdered ? `${start + i}. ` : "- "));
+		},
+	},
+	{
+		bold: { open: "**", close: "**", mixable: true, expelEnclosingWhitespace: true },
+		italic: { open: "*", close: "*", mixable: true, expelEnclosingWhitespace: true },
+		strike: { open: "~~", close: "~~", mixable: true, expelEnclosingWhitespace: true },
+		code: { open: "`", close: "`", escape: false },
+		underline: { open: "<u>", close: "</u>" },
+		link: {
+			open: "[",
+			close: (_, mark) => {
+				const title = mark.attrs.title;
+				return title ? `](${mark.attrs.href} "${title}")` : `](${mark.attrs.href})`;
+			},
+		},
+	}
+);
+
+export function prosekitJSONToMarkdown(jsonDoc: schema.NodeJSON): string {
+	try {
+		const node = prosekitSchema.nodeFromJSON(jsonDoc);
+		return markdownSerializer.serialize(node);
+	} catch (error) {
+		console.error("ProseKit → Markdown conversion failed:", error);
+		return "[Invalid content]";
+	}
+}

--- a/apps/worker/prosekit/resolveMentions.ts
+++ b/apps/worker/prosekit/resolveMentions.ts
@@ -1,0 +1,55 @@
+import { db, schema } from "@repo/database";
+import { formatTaskKey } from "@repo/util";
+import { and, eq } from "drizzle-orm";
+
+/**
+ * Ported copy of apps/backend/prosekit/resolveMentions.ts — the worker's
+ * Docker build prunes out apps/backend, so this can't be a cross-app import
+ * (same reason schema.ts/markdown.ts in this directory are ported copies
+ * rather than shared imports). Keep the two in sync if either changes.
+ *
+ * Before serializing a task description to markdown for the outbound
+ * GitHub sync sweep, rewrites every `kind: "task"` mention's fallback
+ * `value` into a real markdown link to the task's public URL — the
+ * serializer otherwise just writes `value` verbatim as plain text.
+ *
+ * Leaves `value` untouched when the mentioned task can't be resolved, or is
+ * private — this content is headed to a public GitHub issue, so a private
+ * task's existence/title must never leak into it via a link.
+ */
+export async function resolveMentionLinksForGithub(doc: schema.NodeJSON, orgId: string): Promise<schema.NodeJSON> {
+	const org = await db.query.organization.findFirst({
+		where: eq(schema.organization.id, orgId),
+		columns: { shortId: true, slug: true },
+	});
+	if (!org) return doc;
+	// Rebind so the nested closure below narrows correctly — TS doesn't
+	// carry the `!org` guard's narrowing across a function boundary.
+	const resolvedOrg = org;
+
+	async function walk(node: unknown): Promise<unknown> {
+		if (!node || typeof node !== "object") return node;
+		const n = node as { type?: string; attrs?: Record<string, unknown>; content?: unknown[] };
+
+		if (n.type === "mention" && n.attrs?.kind === "task" && n.attrs?.id) {
+			const task = await db.query.task.findFirst({
+				where: and(eq(schema.task.id, n.attrs.id as string), eq(schema.task.organizationId, orgId)),
+				columns: { shortId: true, visible: true },
+			});
+			if (task?.visible === "public") {
+				const url = `https://${resolvedOrg.slug}.${process.env.VITE_ROOT_DOMAIN}/${task.shortId}`;
+				const key = formatTaskKey(resolvedOrg.shortId, task.shortId);
+				return { ...n, attrs: { ...n.attrs, value: `[${key}](${url})` } };
+			}
+			return n;
+		}
+
+		if (Array.isArray(n.content)) {
+			return { ...n, content: await Promise.all(n.content.map(walk)) };
+		}
+
+		return n;
+	}
+
+	return (await walk(doc)) as schema.NodeJSON;
+}

--- a/apps/worker/prosekit/schema.ts
+++ b/apps/worker/prosekit/schema.ts
@@ -1,0 +1,351 @@
+import { Schema } from "prosemirror-model";
+
+// Mirrors apps/backend/prosekit/schema.ts verbatim. Duplicated (not imported)
+// because apps/worker and apps/backend are independently deployed — the
+// worker's Docker build runs `turbo prune worker --docker`, which excludes
+// sibling apps entirely, so a cross-app import would build locally but break
+// in production. Keep this in sync with the backend copy by hand; see the
+// `list` node comment below for why drift here is dangerous.
+export const prosekitSchema = new Schema({
+	nodes: {
+		doc: {
+			content: "block+",
+		},
+		text: {
+			group: "inline",
+		},
+		paragraph: {
+			content: "inline*",
+			group: "block",
+			parseDOM: [{ tag: "p" }],
+			toDOM: () => ["p", 0],
+		},
+		heading: {
+			attrs: { level: { default: 1 } },
+			content: "inline*",
+			group: "block",
+			defining: true,
+			parseDOM: [
+				{ tag: "h1", attrs: { level: 1 } },
+				{ tag: "h2", attrs: { level: 2 } },
+				{ tag: "h3", attrs: { level: 3 } },
+				{ tag: "h4", attrs: { level: 4 } },
+				{ tag: "h5", attrs: { level: 5 } },
+				{ tag: "h6", attrs: { level: 6 } },
+			],
+			toDOM: (node) => [`h${node.attrs.level}`, 0],
+		},
+		blockquote: {
+			content: "block+",
+			group: "block",
+			defining: true,
+			parseDOM: [{ tag: "blockquote" }],
+			toDOM: () => ["blockquote", 0],
+		},
+		codeBlock: {
+			attrs: { language: { default: "" } },
+			content: "text*",
+			marks: "",
+			group: "block",
+			code: true,
+			defining: true,
+			parseDOM: [
+				{
+					tag: "pre",
+					preserveWhitespace: "full",
+					getAttrs: (node) => ({
+						language: (node as HTMLElement).getAttribute("data-language") || "",
+					}),
+				},
+			],
+			toDOM: (node) => ["pre", { "data-language": node.attrs.language }, ["code", 0]],
+		},
+		bulletList: {
+			content: "listItem+",
+			group: "block",
+			parseDOM: [{ tag: "ul" }],
+			toDOM: () => ["ul", 0],
+		},
+		orderedList: {
+			attrs: { start: { default: 1 } },
+			content: "listItem+",
+			group: "block",
+			parseDOM: [
+				{
+					tag: "ol",
+					getAttrs: (node) => ({
+						start: (node as HTMLElement).hasAttribute("start")
+							? Number((node as HTMLElement).getAttribute("start"))
+							: 1,
+					}),
+				},
+			],
+			toDOM: (node) => (node.attrs.start === 1 ? ["ol", 0] : ["ol", { start: node.attrs.start }, 0]),
+		},
+		listItem: {
+			content: "paragraph block*",
+			parseDOM: [{ tag: "li" }],
+			toDOM: () => ["li", 0],
+			defining: true,
+		},
+		horizontalRule: {
+			group: "block",
+			parseDOM: [{ tag: "hr" }],
+			toDOM: () => ["hr"],
+		},
+		hardBreak: {
+			inline: true,
+			group: "inline",
+			selectable: false,
+			parseDOM: [{ tag: "br" }],
+			toDOM: () => ["br"],
+		},
+		image: {
+			attrs: {
+				src: { default: null },
+				alt: { default: null },
+				title: { default: null },
+				width: { default: null },
+				height: { default: null },
+			},
+			group: "block",
+			draggable: true,
+			parseDOM: [
+				{
+					tag: "img[src]",
+					getAttrs: (node) => ({
+						src: (node as HTMLElement).getAttribute("src"),
+						alt: (node as HTMLElement).getAttribute("alt"),
+						title: (node as HTMLElement).getAttribute("title"),
+						width: (node as HTMLElement).getAttribute("width"),
+						height: (node as HTMLElement).getAttribute("height"),
+					}),
+				},
+			],
+			toDOM: (node) => ["img", node.attrs],
+		},
+		video: {
+			attrs: {
+				src: { default: null },
+				width: { default: null },
+				height: { default: null },
+				controls: { default: true },
+				autoplay: { default: false },
+				loop: { default: false },
+				muted: { default: false },
+			},
+			group: "block",
+			atom: true,
+			draggable: true,
+			selectable: true,
+			parseDOM: [
+				{
+					tag: "video",
+					getAttrs: (node) => ({
+						src: (node as HTMLElement).getAttribute("src"),
+						width: (node as HTMLElement).getAttribute("width"),
+						height: (node as HTMLElement).getAttribute("height"),
+						controls: (node as HTMLElement).hasAttribute("controls"),
+						autoplay: (node as HTMLElement).hasAttribute("autoplay"),
+						loop: (node as HTMLElement).hasAttribute("loop"),
+						muted: (node as HTMLElement).hasAttribute("muted"),
+					}),
+				},
+			],
+			toDOM: (node) => {
+				const { src, width, height, controls, autoplay, loop, muted } = node.attrs;
+
+				const attrs: Record<string, string | null> = {
+					src,
+					width,
+					height,
+				};
+
+				if (controls) attrs.controls = "";
+				if (autoplay) attrs.autoplay = "";
+				if (loop) attrs.loop = "";
+				if (muted) attrs.muted = "";
+
+				return ["video", attrs];
+			},
+		},
+		gif: {
+			attrs: {
+				src: { default: null },
+				width: { default: null },
+				height: { default: null },
+			},
+			group: "block",
+			draggable: true,
+			parseDOM: [
+				{
+					tag: "img[src]",
+					getAttrs: (node) => ({
+						src: (node as HTMLElement).getAttribute("src"),
+						width: (node as HTMLElement).getAttribute("width"),
+						height: (node as HTMLElement).getAttribute("height"),
+					}),
+				},
+			],
+			toDOM: (node) => ["img", node.attrs],
+		},
+		mention: {
+			attrs: {
+				id: { default: null },
+				value: { default: "" },
+				kind: { default: null },
+			},
+			group: "inline",
+			inline: true,
+			atom: true,
+			parseDOM: [
+				{
+					tag: "span[data-mention]",
+					getAttrs: (node) => ({
+						id: (node as HTMLElement).getAttribute("data-id"),
+						kind: (node as HTMLElement).getAttribute("data-mention"),
+						value: (node as HTMLElement).textContent || "",
+					}),
+				},
+			],
+			toDOM: (node) => [
+				"span",
+				{
+					class: "mention",
+					"data-kind": node.attrs.kind,
+					"data-id": node.attrs.id,
+				},
+				node.attrs.value,
+			],
+		},
+		table: {
+			content: "tableRow+",
+			group: "block",
+			tableRole: "table",
+			isolating: true,
+			parseDOM: [{ tag: "table" }],
+			toDOM: () => ["table", ["tbody", 0]],
+		},
+		tableRow: {
+			content: "(tableCell | tableHeader)*",
+			tableRole: "row",
+			parseDOM: [{ tag: "tr" }],
+			toDOM: () => ["tr", 0],
+		},
+		tableCell: {
+			attrs: {
+				colspan: { default: 1 },
+				rowspan: { default: 1 },
+			},
+			content: "block+",
+			tableRole: "cell",
+			isolating: true,
+			parseDOM: [
+				{
+					tag: "td",
+					getAttrs: (node) => ({
+						colspan: Number((node as HTMLElement).getAttribute("colspan")) || 1,
+						rowspan: Number((node as HTMLElement).getAttribute("rowspan")) || 1,
+					}),
+				},
+			],
+			toDOM: (node) => ["td", node.attrs, 0],
+		},
+		tableHeader: {
+			attrs: {
+				colspan: { default: 1 },
+				rowspan: { default: 1 },
+			},
+			content: "block+",
+			tableRole: "header_cell",
+			isolating: true,
+			parseDOM: [
+				{
+					tag: "th",
+					getAttrs: (node) => ({
+						colspan: Number((node as HTMLElement).getAttribute("colspan")) || 1,
+						rowspan: Number((node as HTMLElement).getAttribute("rowspan")) || 1,
+					}),
+				},
+			],
+			toDOM: (node) => ["th", node.attrs, 0],
+		},
+		// Matches @prosekit/extensions/list's real node spec (backed by
+		// prosemirror-flat-list) — the actual editor's schema has a single
+		// flat "list" node with `content: "block+"` and no separate
+		// "listItem" wrapper; nested lists are just adjacent "list" nodes
+		// inside a parent list's content, not wrapped in a list-item node.
+		// This must stay structurally identical to prosemirror-flat-list's
+		// `createListSpec()`, or NodeJSON produced here (e.g. by
+		// markdownToProsekitJSON) fails with "Unknown node type" when the
+		// frontend editor tries to load it — content/attrs shape is read by
+		// name, not validated against this schema.
+		list: {
+			content: "block+",
+			group: "list block",
+			attrs: {
+				kind: { default: "bullet" }, // "bullet" | "ordered" | "task" | "toggle"
+				order: { default: null },
+				checked: { default: false },
+				collapsed: { default: false },
+			},
+			parseDOM: [
+				{ tag: "ul", attrs: { kind: "bullet" } },
+				{
+					tag: "ol",
+					getAttrs: (node) => ({
+						kind: "ordered",
+						order: Number((node as HTMLElement).getAttribute("start")) || 1,
+					}),
+				},
+			],
+			toDOM: (node) => (node.attrs.kind === "ordered" ? ["ol", { start: node.attrs.order }, 0] : ["ul", 0]),
+		},
+	},
+	marks: {
+		bold: {
+			parseDOM: [
+				{ tag: "strong" },
+				{ tag: "b" },
+				{
+					style: "font-weight",
+					getAttrs: (value) => /^(bold(er)?|[5-9]\d{2,})$/.test(value as string) && null,
+				},
+			],
+			toDOM: () => ["strong", 0],
+		},
+		italic: {
+			parseDOM: [{ tag: "i" }, { tag: "em" }, { style: "font-style=italic" }],
+			toDOM: () => ["em", 0],
+		},
+		underline: {
+			parseDOM: [{ tag: "u" }, { style: "text-decoration=underline" }],
+			toDOM: () => ["u", 0],
+		},
+		strike: {
+			parseDOM: [{ tag: "s" }, { tag: "del" }, { tag: "strike" }, { style: "text-decoration=line-through" }],
+			toDOM: () => ["s", 0],
+		},
+		code: {
+			parseDOM: [{ tag: "code" }],
+			toDOM: () => ["code", 0],
+		},
+		link: {
+			attrs: {
+				href: { default: "" },
+				title: { default: null },
+			},
+			inclusive: false,
+			parseDOM: [
+				{
+					tag: "a[href]",
+					getAttrs: (node) => ({
+						href: (node as HTMLElement).getAttribute("href"),
+						title: (node as HTMLElement).getAttribute("title"),
+					}),
+				},
+			],
+			toDOM: (mark) => ["a", { href: mark.attrs.href, title: mark.attrs.title }, 0],
+		},
+	},
+});

--- a/apps/worker/tsconfig.json
+++ b/apps/worker/tsconfig.json
@@ -16,6 +16,7 @@
 		"index.ts",
 		"queue.ts",
 		"github",
+		"prosekit",
 		"worker.ts",
 		"tracing.ts"
 	],

--- a/package.json
+++ b/package.json
@@ -18,8 +18,10 @@
     "check-types": "turbo check-types",
     "docker": "docker-compose down --remove-orphans --volumes && docker container prune -f && docker-compose up --build -d",
     "docker:build": "docker-compose -f docker-compose.yml build",
-    "env:all": "bash -c 'failed=0; bash ./gen.sh Sayr sayr-dev-local ./apps/worker/.env || failed=1; bash ./gen.sh Sayr sayr-dev-local ./apps/backend/.env || failed=1; bash ./gen.sh Sayr sayr-dev-local ./apps/start/.env || failed=1; bash ./gen.sh Sayr sayr-marketing-dev ./apps/marketing/.env || failed=1; exit $failed'",
-    "env:ps:all": "powershell -Command \"./gen.ps1 Sayr sayr-dev-local ./apps/worker/.env; ./gen.ps1 Sayr sayr-dev-local ./apps/backend/.env; ./gen.ps1 Sayr sayr-dev-local ./apps/start/.env; ./gen.ps1 Sayr sayr-marketing-dev ./apps/marketing/.env\"",
+    "env:all": "bash -c 'failed=0; bash ./gen.sh Sayr sayr-dev-local ./apps/worker/.env || failed=1; bash ./gen.sh Sayr sayr-dev-local ./apps/backend/.env || failed=1; bash ./gen.sh Sayr sayr-dev-local ./apps/start/.env || failed=1; bash ./gen.sh Sayr sayr-dev-local ./packages/database/.env || failed=1; bash ./gen.sh Sayr sayr-marketing-dev ./apps/marketing/.env || failed=1; exit $failed'",
+    "env:ps:all": "powershell -Command \"./gen.ps1 Sayr sayr-dev-local ./apps/worker/.env; ./gen.ps1 Sayr sayr-dev-local ./apps/backend/.env; ./gen.ps1 Sayr sayr-dev-local ./apps/start/.env; ./gen.ps1 Sayr sayr-dev-local ./packages/database/.env; ./gen.ps1 Sayr sayr-marketing-dev ./apps/marketing/.env\"",
+    "env:local:all": "bash -c '[ -s .env.local ] || { echo \"root .env.local is missing or empty\" >&2; exit 1; }; for d in apps/worker apps/backend apps/start apps/marketing packages/database; do cp .env.local \"$d/.env.local\"; done'",
+    "env:local:ps:all": "powershell -Command \"if (-not (Test-Path .env.local) -or (Get-Item .env.local).Length -eq 0) { Write-Error 'root .env.local is missing or empty'; exit 1 }; foreach ($d in 'apps/worker','apps/backend','apps/start','apps/marketing','packages/database') { Copy-Item .env.local (Join-Path $d '.env.local') -Force }\"",
     "create-integration": "pnpm -F @repo/create-integration start"
   },
   "devDependencies": {

--- a/packages/database/src/functions/github.ts
+++ b/packages/database/src/functions/github.ts
@@ -1,0 +1,58 @@
+import { and, eq, isNull } from "drizzle-orm";
+import { db, schema } from "..";
+
+/**
+ * Resolves the single GitHub repository link a task-sync path should use for
+ * an organization, given an optional task category.
+ *
+ * Tries an exact category match first (a repo explicitly linked to that
+ * category), then falls back to the catch-all repo link (`categoryId IS
+ * NULL`). Only ever returns `enabled` links.
+ *
+ * This is the single source of truth for "which repo does this org's GitHub
+ * sync use" — every sync path (task creation, status-close, description
+ * sync, comment sync) should call this instead of hand-rolling the
+ * exact-then-catchall lookup. Callers are still responsible for their own
+ * `task.visible === "private"` skip — this helper only resolves the repo
+ * link, it doesn't know about any particular task.
+ *
+ * @param orgId - The organization ID to look up a linked repo for.
+ * @param categoryId - Optional task category ID to try an exact match against first.
+ * @returns The matching `githubRepository` row, or `null` if none is linked/enabled.
+ *
+ * @example
+ * ```ts
+ * const repoLink = await findSyncEligibleGithubRepo(orgId, task.category);
+ * if (!repoLink) return; // nothing to sync to
+ * ```
+ */
+export async function findSyncEligibleGithubRepo(
+	orgId: string,
+	categoryId?: string | null
+): Promise<schema.githubRepositoryType | null> {
+	let foundLink: schema.githubRepositoryType | undefined;
+
+	// 1. Try exact category match (if a category was provided)
+	if (categoryId) {
+		foundLink = await db.query.githubRepository.findFirst({
+			where: and(
+				eq(schema.githubRepository.organizationId, orgId),
+				eq(schema.githubRepository.categoryId, categoryId),
+				eq(schema.githubRepository.enabled, true)
+			),
+		});
+	}
+
+	// 2. Fallback to catch-all (categoryId IS NULL)
+	if (!foundLink) {
+		foundLink = await db.query.githubRepository.findFirst({
+			where: and(
+				eq(schema.githubRepository.organizationId, orgId),
+				isNull(schema.githubRepository.categoryId),
+				eq(schema.githubRepository.enabled, true)
+			),
+		});
+	}
+
+	return foundLink ?? null;
+}

--- a/packages/database/src/functions/index.ts
+++ b/packages/database/src/functions/index.ts
@@ -9,6 +9,7 @@ export * from "./release";
 export * from "./notification";
 export * from "./integrations";
 export * from "./user";
+export * from "./github";
 
 /**
  * Standard columns for user summary in Drizzle relation queries.

--- a/packages/queue/src/groups/github.ts
+++ b/packages/queue/src/groups/github.ts
@@ -29,6 +29,8 @@ export type GithubIssueOpenedPayload = GithubRepoContext & {
 	title: string;
 	body: string;
 	user: string;
+	userId?: number;
+	categoryId?: string | null;
 };
 
 export type GithubIssueCommentPayload = GithubRepoContext & {

--- a/packages/queue/src/groups/github.ts
+++ b/packages/queue/src/groups/github.ts
@@ -31,6 +31,7 @@ export type GithubIssueOpenedPayload = GithubRepoContext & {
 	user: string;
 	userId?: number;
 	categoryId?: string | null;
+	installationId: number;
 };
 
 export type GithubIssueCommentPayload = GithubRepoContext & {

--- a/packages/queue/src/groups/github.ts
+++ b/packages/queue/src/groups/github.ts
@@ -40,6 +40,30 @@ export type GithubIssueCommentPayload = GithubRepoContext & {
 	pull_request?: boolean;
 };
 
+export type GithubIssueEditedPayload = GithubRepoContext & {
+	number: number;
+	title: string;
+	body: string;
+	user: string;
+};
+
+export type GithubIssueCommentEditedPayload = GithubRepoContext & {
+	number: number;
+	commentId: number;
+	commentBody: string;
+	user: string;
+	userId?: number;
+	pull_request?: boolean;
+};
+
+export type GithubIssueCommentDeletedPayload = GithubRepoContext & {
+	number: number;
+	commentId: number;
+	user: string;
+	userId?: number;
+	pull_request?: boolean;
+};
+
 /* ============================================================
    Keyword Parsing (Issues / PRs / Comments)
    ============================================================ */
@@ -100,7 +124,7 @@ export type GithubPullRequestLinkPayload = GithubRepoContext & {
 	userId?: number;
 	author: string;
 	draft: boolean;
-	state: "open" | "closed" | "all"
+	state: "open" | "closed" | "all";
 
 	matches: {
 		keyword: string;
@@ -145,45 +169,62 @@ export type GithubBranchCreatePayload = GithubRepoContext & {
 
 export type GithubJob =
 	| {
-		type: "issue_opened";
-		traceContext?: TraceContext;
-		payload: GithubIssueOpenedPayload;
-	}
+			type: "issue_opened";
+			traceContext?: TraceContext;
+			payload: GithubIssueOpenedPayload;
+	  }
 	| {
-		type: "issue_comment";
-		traceContext?: TraceContext;
-		payload: GithubIssueCommentPayload;
-	}
+			type: "issue_comment";
+			traceContext?: TraceContext;
+			payload: GithubIssueCommentPayload;
+	  }
 	| {
-		type: "sayr_keyword_parse";
-		traceContext?: TraceContext;
-		payload: GithubSayrKeywordParsePayload;
-	}
+			type: "issue_edited";
+			traceContext?: TraceContext;
+			payload: GithubIssueEditedPayload;
+	  }
 	| {
-		type: "github_commit_ref";
-		traceContext?: TraceContext;
-		payload: GithubCommitRefPayload;
-	}
+			type: "issue_comment_edited";
+			traceContext?: TraceContext;
+			payload: GithubIssueCommentEditedPayload;
+	  }
 	| {
-		type: "pull_request_link";
-		traceContext?: TraceContext;
-		payload: GithubPullRequestLinkPayload;
-	}
+			type: "issue_comment_deleted";
+			traceContext?: TraceContext;
+			payload: GithubIssueCommentDeletedPayload;
+	  }
 	| {
-		type: "pull_request_sync";
-		traceContext?: TraceContext;
-		payload: GithubPullRequestSyncPayload;
-	}
+			type: "sayr_keyword_parse";
+			traceContext?: TraceContext;
+			payload: GithubSayrKeywordParsePayload;
+	  }
 	| {
-		type: "pull_request_closed";
-		traceContext?: TraceContext;
-		payload: GithubPullRequestClosedPayload;
-	} | {
-		type: "branch_create";
-		traceContext?: TraceContext;
-		payload: GithubBranchCreatePayload;
-	} | {
-		type: "branch_delete";
-		traceContext?: TraceContext;
-		payload: GithubBranchCreatePayload;
-	};
+			type: "github_commit_ref";
+			traceContext?: TraceContext;
+			payload: GithubCommitRefPayload;
+	  }
+	| {
+			type: "pull_request_link";
+			traceContext?: TraceContext;
+			payload: GithubPullRequestLinkPayload;
+	  }
+	| {
+			type: "pull_request_sync";
+			traceContext?: TraceContext;
+			payload: GithubPullRequestSyncPayload;
+	  }
+	| {
+			type: "pull_request_closed";
+			traceContext?: TraceContext;
+			payload: GithubPullRequestClosedPayload;
+	  }
+	| {
+			type: "branch_create";
+			traceContext?: TraceContext;
+			payload: GithubBranchCreatePayload;
+	  }
+	| {
+			type: "branch_delete";
+			traceContext?: TraceContext;
+			payload: GithubBranchCreatePayload;
+	  };


### PR DESCRIPTION
## Summary

Closes SAY-41. Adds two-way sync between Sayr tasks and their linked GitHub issues for **public tasks linked to public repos** — descriptions, comments (create/edit/delete), and now includes the real task description on initial issue creation instead of a placeholder link-back. Outbound comments post as the real Sayr author via their own linked GitHub account when available, falling back to a bot + attribution line otherwise.

## What changed

### Two-way sync (SAY-41 core)
- **Inbound (GitHub → Sayr)**: issue `edited` now updates the linked task's title/description; `issue_comment` `edited`/`deleted` now updates/removes the mirrored Sayr comment. Previously only `opened`/`created` were handled at all.
- **Outbound (Sayr → GitHub)**:
  - New public comments, edits, deletes, and public→internal visibility flips on a task's comments now sync to the linked GitHub issue.
  - Task descriptions/titles sync to GitHub on a ~1-minute batched sweep (not real-time — by design, see task discussion) rather than per-keystroke.
  - Task creation now sends the real description as the initial GitHub issue body, converted via the existing ProseKit→Markdown serializer, instead of a placeholder link-back.
- Every sync path gates on the task being `visible: "public"` and the linked repo being non-private (checked live against GitHub, not just cached), so private tasks/repos are untouched.
- Fixed a pre-existing bug in the status-close sync path (`updateTaskService`): it only checked the catch-all (no-category) repo link and never gated on private tasks, unlike task creation's equivalent check. Consolidated into a single `findSyncEligibleGithubRepo` helper (`packages/database/src/functions/github.ts`) used everywhere.
- Loop prevention: extended the existing bot-sender webhook filter to the new `edited`/`deleted` events.

### Comment attribution
- Outbound comments now identify who actually wrote them on Sayr, instead of showing up as an anonymous bot post:
  - If the author has a linked GitHub account, the comment posts **as them directly** (their real avatar/username) using their own GitHub OAuth token — reuses the existing `refreshGitHubTokenIfNeeded` helper already used by the org/installation routes.
  - Otherwise, falls back to the App's bot identity with a `"**Name** commented via Sayr:"` prefix.
- New invisible `<!-- sayr-comment-sync -->` marker (`apps/backend/util.ts`) appended to every outbound comment: since a comment posted via a real user's own token comes back through the webhook with a genuine (non-bot) username, the old bot-suffix-only filter would otherwise treat the resulting echo as a brand-new inbound comment and duplicate it. The webhook handler now also checks for this marker.

### `package.json`
- Fixed a leftover `--filter=landing --filter=landing` duplicate (incomplete marketing→landing rename) in `dev:op`/`dev:ce`/`dev:cloud`.
- Added `env:local:all` / `env:local:ps:all`: an alternative to the existing 1Password-based `env:all`/`env:ps:all` that fans a manually-maintained root `.env.local` out to every service's `.env.local`, for local dev without requiring `op`.
- Added `packages/database` to all four env-sync scripts — it has its own `.env`/`.env.local` (needed for `drizzle-kit generate/migrate/studio`) but was never covered by the existing scripts.

## Explicitly out of scope (see plan discussion)
- GitHub issue → new Sayr task auto-creation (stays link-only via `Ref #N` keywords, as before).
- Any change to private-repo/private-task sync behavior.
- Comment reactions sync, label sync, assignee sync (discussed, deferred — GitHub's assignee API requires the assignee to be a repo collaborator, silently dropping anyone who isn't, so it needs its own scoping pass).
- New frontend UI (no sync-status indicator added).

## Verification
- `tsc --noEmit` clean against baseline in `apps/backend`, `apps/worker`, `packages/database`, `packages/queue` (zero new errors introduced, confirmed by diffing against a pre-change baseline).
- Biome-formatted per app.
- Manually tested end-to-end against a live test org/repo: issue edit → task update, task edit → issue update (via the sweep), comment round-trips in both directions including edit/delete, and comment attribution both via bot fallback and via a real linked GitHub account.
