### PR TITLE
Fix CLI publish 404: add repository field to packages/cli/package.json

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -4,6 +4,11 @@
 	"description": "Sayr.io command-line interface — manage tasks and comments from your terminal",
 	"license": "MIT",
 	"type": "module",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/dorasto/sayr.git",
+		"directory": "packages/cli"
+	},
 	"bin": {
 		"sayr": "dist/index.js"
 	},


### PR DESCRIPTION
## What broke

The [Publish CLI](https://github.com/dorasto/sayr/actions/runs/34697324369/job/103562955773) workflow failed publishing `@sayrio/cli@0.2.0` after this PR's merge, with:

```
npm error code E404
npm error 404 Not Found - PUT https://registry.npmjs.org/@sayrio%2fcli
npm error 404 The requested resource '@sayrio/cli@0.2.0' could not be found or you do not have permission to access it.
```

This happened *after* npm successfully signed and logged the provenance statement to sigstore — the failure is specifically in the OIDC Trusted Publishing auth exchange for the actual publish.

## Root cause

`packages/cli/package.json` had no `repository` field. Per npm's own [Trusted Publishing docs](https://docs.npmjs.com/trusted-publishers): *"To publish from GitHub, your package's `repository.url` field in `package.json` must exactly match your GitHub repository."* Without it, npm can't verify the package is linked to this repo and rejects the OIDC-derived publish token — reported as a 404 rather than a clearer permission error (a known rough edge of the feature).

## Fix

Added the standard monorepo form:
```json
"repository": {
  "type": "git",
  "url": "git+https://github.com/dorasto/sayr.git",
  "directory": "packages/cli"
}
```

## One more thing to check on npmjs.com (I can't verify this myself)

npm's docs also require the Trusted Publisher's **Workflow filename** field (on the `@sayrio/cli` package's Settings → Publishing access page) to be the **bare filename** `publish-cli.yml`, not the full path `.github/workflows/publish-cli.yml`. If this PR merges and the next publish still 404s, that's the next thing to check.

Merging this won't itself trigger a republish (needs a PR that touches `packages/cli/**`, which this does) — the next merge should retry the `0.2.0` publish automatically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added repository metadata to the CLI package for improved project traceability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->