### PR TITLE
Fix release-on-merge.yml misclassifying releases via cli-release:* label collision

### DIFF
--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -32,16 +32,23 @@ jobs:
         run: |
           echo "Labels: $PR_LABELS"
 
-          if echo "$PR_LABELS" | grep -q "release:major"; then
+          # Quoted to anchor on the exact JSON array entry ("release:major"),
+          # not a bare substring — otherwise "cli-release:minor" also matches
+          # the unanchored "release:minor" check below it and gets treated as
+          # an app release (this actually happened: PRs #314 and #315 both
+          # carried a cli-release:* label alongside their real release:*
+          # label and got misclassified, firing an unintended app version
+          # bump plus a full backend/worker/start build-and-deploy each time).
+          if echo "$PR_LABELS" | grep -q '"release:major"'; then
             echo "bump=major" >> $GITHUB_OUTPUT
             echo "Detected: MAJOR release"
-          elif echo "$PR_LABELS" | grep -q "release:minor"; then
+          elif echo "$PR_LABELS" | grep -q '"release:minor"'; then
             echo "bump=minor" >> $GITHUB_OUTPUT
             echo "Detected: MINOR release"
-          elif echo "$PR_LABELS" | grep -q "release:patch"; then
+          elif echo "$PR_LABELS" | grep -q '"release:patch"'; then
             echo "bump=patch" >> $GITHUB_OUTPUT
             echo "Detected: PATCH release"
-          elif echo "$PR_LABELS" | grep -q "release:skip"; then
+          elif echo "$PR_LABELS" | grep -q '"release:skip"'; then
             echo "bump=skip" >> $GITHUB_OUTPUT
             echo "Detected: SKIP release"
           else

--- a/apps/landing/content/docs/cli.mdx
+++ b/apps/landing/content/docs/cli.mdx
@@ -14,6 +14,13 @@ npm install -g @sayrio/cli
 sayr --help
 ```
 
+<Callout type="warning" title="Windows users">
+  Running `npm install -g @sayrio/cli` may appear to run successfully but when
+  attempting to run `sayr` commands you may get some errors. The workaround is
+  to run the install command via an admin privillaged terminal. Usual Sayr
+  commands should work in non-admin terminals there after.
+</Callout>
+
 Prefer a one-off run without a global install? `npx @sayrio/cli --help` works the same way.
 
 ## Authentication
@@ -44,21 +51,21 @@ sayr config set-base-url http://localhost:5468
 
 ## Commands
 
-| Command | What it does |
-|---|---|
-| `sayr login [--token] [--base-url]` | Authenticate and store credentials |
-| `sayr logout` | Clear stored credentials |
-| `sayr whoami` | Show the authenticated user |
-| `sayr orgs list` | List organizations you belong to |
-| `sayr task create <title>` | Create a task |
-| `sayr task list` | List tasks — search, filter, sort, paginate |
-| `sayr task view <taskId>` | Show a single task |
-| `sayr task update <taskId>` | Update title, status, priority, category, release, or visibility |
-| `sayr task label <taskId> --set <ids>` | Replace a task's full set of labels |
-| `sayr task assign <taskId> --set <ids>` | Replace a task's full set of assignees |
-| `sayr comment create <taskId> <content>` | Post a comment on a task |
-| `sayr comment update <commentId> <content>` | Edit a comment |
-| `sayr comment delete <commentId>` | Delete a comment |
+| Command                                     | What it does                                                     |
+| ------------------------------------------- | ---------------------------------------------------------------- |
+| `sayr login [--token] [--base-url]`         | Authenticate and store credentials                               |
+| `sayr logout`                               | Clear stored credentials                                         |
+| `sayr whoami`                               | Show the authenticated user                                      |
+| `sayr orgs list`                            | List organizations you belong to                                 |
+| `sayr task create <title>`                  | Create a task                                                    |
+| `sayr task list`                            | List tasks — search, filter, sort, paginate                      |
+| `sayr task view <taskId>`                   | Show a single task                                               |
+| `sayr task update <taskId>`                 | Update title, status, priority, category, release, or visibility |
+| `sayr task label <taskId> --set <ids>`      | Replace a task's full set of labels                              |
+| `sayr task assign <taskId> --set <ids>`     | Replace a task's full set of assignees                           |
+| `sayr comment create <taskId> <content>`    | Post a comment on a task                                         |
+| `sayr comment update <commentId> <content>` | Edit a comment                                                   |
+| `sayr comment delete <commentId>`           | Delete a comment                                                 |
 
 Every command accepts `--json` for scriptable output, and `sayr <command> --help` prints its full flag list.
 
@@ -89,7 +96,10 @@ sayr comment create 123 "Deploy finished successfully." --json
 The CLI can only do what your personal access token's scopes — and your own role in the organization — allow. Reading tasks needs `tasks.read`, creating them needs `tasks.create`, commenting needs `tasks.comment`, and so on down to `content.manageLabels`, `tasks.assign`, `tasks.changeStatus`, `tasks.changePriority`, and `tasks.editAny`. A key is always a ceiling, never a grant — it can never do more than its owner can, and it can never touch member, team, or billing management no matter what scopes it's given.
 
 <Callout type="info" title="Plain text on updates">
-`task update --description` and `comment update` accept plain text only, not Markdown. Creating a task or comment accepts Markdown (converted server-side); the update endpoints expect an already-parsed document instead, which the CLI can't produce from Markdown yet.
+  `task update --description` and `comment update` accept plain text only, not
+  Markdown. Creating a task or comment accepts Markdown (converted server-side);
+  the update endpoints expect an already-parsed document instead, which the CLI
+  can't produce from Markdown yet.
 </Callout>
 
 ## Related

--- a/apps/landing/content/features/github.mdx
+++ b/apps/landing/content/features/github.mdx
@@ -31,11 +31,11 @@ Closed SAY-201
 Resolves SAY-205
 ```
 
-<Callout label="Public visibility of code activity">
+<FeatureCallout label="Public visibility of code activity">
 	When a task is public, PR merges and issue references that come from public repositories will appear on the task's
 	public timeline — your users can see that their requested feature was shipped with a specific PR. Activity from
 	private repositories stays internal only.
-</Callout>
+</FeatureCallout>
 
 ## Pull request lifecycle tracking
 

--- a/apps/landing/content/features/public-portal.mdx
+++ b/apps/landing/content/features/public-portal.mdx
@@ -8,10 +8,10 @@ Every Sayr organization gets a live public board hosted at `org.sayr.io`. It's a
 
 It's not a status page. It's not a changelog. It's your actual task board, filtered to what's appropriate for external eyes.
 
-<Callout label="Live example">
+<FeatureCallout label="Live example">
 	A software team might share their in-progress feature work and open bug reports publicly while keeping internal
 	sprint planning tasks, architectural decisions, and staff-only discussions completely hidden.
-</Callout>
+</FeatureCallout>
 
 ## How it works
 

--- a/apps/landing/content/features/self-hosting.mdx
+++ b/apps/landing/content/features/self-hosting.mdx
@@ -8,10 +8,10 @@ For some teams, using a hosted SaaS product for project management is a non-star
 
 Sayr is built with self-hosting as a first-class concern. The same codebase that runs `sayr.io` is the same codebase you deploy yourself.
 
-<Callout label="Source availablee">
+<FeatureCallout label="Source availablee">
 	The full Sayr source code is available on GitHub at github.com/dorasto/sayr. Every line of the backend, frontend,
 	and worker is public. Fork it, inspect it, contribute to it.
-</Callout>
+</FeatureCallout>
 
 ## What you need to deploy
 

--- a/apps/landing/content/features/tasks.mdx
+++ b/apps/landing/content/features/tasks.mdx
@@ -57,9 +57,9 @@ Group tasks into releases (milestones, sprints, versions). Each release has a ta
 
 The release sidebar shows a progress chart, status breakdown, priority distribution, and assignee workload at a glance. Marking a release as Released auto-closes any open tasks in it.
 
-<Callout label="Available on Pro">
+<FeatureCallout label="Available on Pro">
 	Releases are available on the Pro plan and all self-hosted editions. The Free tier does not include releases.
-</Callout>
+</FeatureCallout>
 
 ## Issue templates
 

--- a/apps/landing/content/features/visibility.mdx
+++ b/apps/landing/content/features/visibility.mdx
@@ -13,11 +13,11 @@ Most tools treat privacy as an all-or-nothing setting — either your board is p
 
 This means a single task can have public content visible on the portal alongside internal comments and private labels that your users never see.
 
-<Callout label="How it works in practice">
+<FeatureCallout label="How it works in practice">
 	A task titled "Fix payment processing bug" might be set to public so users can track it. The comments from your
 	engineering team about root cause analysis are marked internal. The label "Critical — P0" is set private. Users see
 	the task and its public updates; your team sees everything.
-</Callout>
+</FeatureCallout>
 
 ## Defaults and bulk updates
 

--- a/apps/landing/content/features/voting.mdx
+++ b/apps/landing/content/features/voting.mdx
@@ -21,10 +21,10 @@ Public users can submit new tasks directly from your portal. Submissions can be:
 
 You can configure per-organization whether blank submissions are allowed, or whether users must pick a template. This keeps incoming feedback structured and actionable rather than noise.
 
-<Callout label="Moderation controls">
+<FeatureCallout label="Moderation controls">
 	You control what public users can set on their submissions — whether they can choose a category, set a label,
 	assign a priority, or only provide a title and description. This keeps your taxonomy clean.
-</Callout>
+</FeatureCallout>
 
 ## Public comments
 

--- a/apps/landing/src/components/features/callout.tsx
+++ b/apps/landing/src/components/features/callout.tsx
@@ -1,12 +1,18 @@
 import type { ReactNode } from "react";
 
-interface CalloutProps {
+interface FeatureCalloutProps {
 	label: string;
 	description?: string;
 	children?: ReactNode;
 }
 
-export function Callout({ label, description, children }: CalloutProps) {
+// Distinct from fumadocs-ui's own <Callout title= type=> (info/warn/error/
+// success/idea, with icon and colored border) used across content/docs/**.
+// This is a plainer marketing-page callout box for content/features/**
+// MDX only — keep it registered under its own tag name in mdx.tsx rather
+// than overriding `Callout`, or docs pages silently lose their real
+// fumadocs Callout (title/type are just unused/undefined props on this one).
+export function FeatureCallout({ label, description, children }: FeatureCalloutProps) {
 	return (
 		<div className="not-prose my-8 rounded-2xl border border-primary/20 bg-primary/[0.03] p-6">
 			<p className="text-xs font-semibold text-primary uppercase tracking-wide mb-2">{label}</p>

--- a/apps/landing/src/components/mdx.tsx
+++ b/apps/landing/src/components/mdx.tsx
@@ -2,7 +2,7 @@ import type { GeneratedPageProps } from "fumadocs-openapi";
 import { createOpenAPIPage, type OpenAPIPageProps_Spec } from "fumadocs-openapi/ui";
 import defaultMdxComponents from "fumadocs-ui/mdx";
 import type { MDXComponents } from "mdx/types";
-import { Callout } from "@/components/features/callout";
+import { FeatureCallout } from "@/components/features/callout";
 import { ComparisonCallout } from "@/components/features/comparison-callout";
 import { FeatureStep } from "@/components/features/feature-step";
 import openapiDocument from "@/data/openapi-public.json";
@@ -32,7 +32,7 @@ function APIPage(props: GeneratedPageProps) {
 export function getMDXComponents(components?: MDXComponents) {
 	return {
 		...defaultMdxComponents,
-		Callout,
+		FeatureCallout,
 		ComparisonCallout,
 		FeatureStep,
 		APIPage,

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -36,9 +36,18 @@ export function registerLoginCommand(program: Command): void {
 				token = answer;
 			}
 
+			// Resolved here rather than left to apiRequest's own fallback chain —
+			// that chain prefers a previously *persisted* config.baseUrl over
+			// DEFAULT_BASE_URL, so a stale local-dev override (e.g. from an
+			// earlier --base-url http://localhost:5468) would otherwise keep
+			// silently redirecting every future plain `login` back to it. login
+			// always means "connect to this URL, or production" — never "whatever
+			// I happened to set last time."
+			const baseUrl = opts.baseUrl ?? DEFAULT_BASE_URL;
+
 			try {
-				const me = await apiRequest<Me>("", { clientOptions: { token, baseUrl: opts.baseUrl } });
-				await updateConfig({ token, ...(opts.baseUrl ? { baseUrl: opts.baseUrl } : {}) });
+				const me = await apiRequest<Me>("", { clientOptions: { token, baseUrl } });
+				await updateConfig({ token, baseUrl });
 				console.log(`${pc.green("✓")} Logged in as ${pc.bold(me.name ?? me.email ?? me.id)}`);
 			} catch (err) {
 				printError(err);

--- a/packages/ui/src/components/context-menu.tsx
+++ b/packages/ui/src/components/context-menu.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import { ContextMenu as ContextMenuPrimitive } from "@base-ui/react/context-menu";
-import { cn } from "@repo/ui/lib/utils";
-import { s } from "framer-motion/client";
+import { cn, overlayPortalContainer } from "@repo/ui/lib/utils";
 import { Check, ChevronRight, Circle } from "lucide-react";
 import type * as React from "react";
 
@@ -43,7 +42,7 @@ function ContextMenuSubTrigger({
 
 function ContextMenuSubContent({ className, ...props }: ContextMenuPrimitive.Popup.Props) {
 	return (
-		<ContextMenuPrimitive.Portal>
+		<ContextMenuPrimitive.Portal container={overlayPortalContainer}>
 			<ContextMenuPrimitive.Positioner
 				className="isolate z-50 outline-none"
 				align="start"
@@ -69,7 +68,7 @@ function ContextMenuContent({
 	...props
 }: ContextMenuPrimitive.Popup.Props & Pick<ContextMenuPrimitive.Positioner.Props, "alignOffset">) {
 	return (
-		<ContextMenuPrimitive.Portal>
+		<ContextMenuPrimitive.Portal container={overlayPortalContainer}>
 			<ContextMenuPrimitive.Positioner className="isolate z-50 outline-none" alignOffset={alignOffset}>
 				<ContextMenuPrimitive.Popup
 					className={cn(

--- a/packages/ui/src/components/dropdown-menu.tsx
+++ b/packages/ui/src/components/dropdown-menu.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Menu as DropdownMenuPrimitive } from "@base-ui/react/menu";
-import { cn } from "@repo/ui/lib/utils";
+import { cn, overlayPortalContainer } from "@repo/ui/lib/utils";
 import { Check, ChevronRight, Circle } from "lucide-react";
 import type * as React from "react";
 
@@ -47,7 +47,7 @@ function DropdownMenuSubTrigger({
 
 function DropdownMenuSubContent({ className, ...props }: DropdownMenuPrimitive.Popup.Props) {
 	return (
-		<DropdownMenuPrimitive.Portal>
+		<DropdownMenuPrimitive.Portal container={overlayPortalContainer}>
 			<DropdownMenuPrimitive.Positioner
 				className="isolate z-50 outline-none"
 				align="start"
@@ -77,7 +77,7 @@ function DropdownMenuContent({
 }: DropdownMenuPrimitive.Popup.Props &
 	Pick<DropdownMenuPrimitive.Positioner.Props, "align" | "alignOffset" | "side" | "sideOffset">) {
 	return (
-		<DropdownMenuPrimitive.Portal>
+		<DropdownMenuPrimitive.Portal container={overlayPortalContainer}>
 			<DropdownMenuPrimitive.Positioner
 				className="isolate z-50 outline-none"
 				align={align}

--- a/packages/ui/src/components/hover-card.tsx
+++ b/packages/ui/src/components/hover-card.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { PreviewCard as HoverCardPrimitive } from "@base-ui/react/preview-card";
-import { cn } from "@repo/ui/lib/utils";
+import { cn, overlayPortalContainer } from "@repo/ui/lib/utils";
 import * as React from "react";
 
 const HoverCard = HoverCardPrimitive.Root;
@@ -15,7 +15,7 @@ const HoverCardContent = React.forwardRef<
 	React.ComponentPropsWithoutRef<typeof HoverCardPrimitive.Popup> &
 		Pick<React.ComponentProps<typeof HoverCardPrimitive.Positioner>, "align" | "alignOffset" | "side" | "sideOffset">
 >(({ className, align = "center", alignOffset, side, sideOffset = 4, ...props }, ref) => (
-	<HoverCardPortal>
+	<HoverCardPortal container={overlayPortalContainer}>
 		<HoverCardPrimitive.Positioner
 			align={align}
 			alignOffset={alignOffset}

--- a/packages/ui/src/components/menubar.tsx
+++ b/packages/ui/src/components/menubar.tsx
@@ -2,7 +2,7 @@
 
 import { Menu as MenubarPrimitive } from "@base-ui/react/menu";
 import { Menubar as MenubarRootPrimitive } from "@base-ui/react/menubar";
-import { cn } from "@repo/ui/lib/utils";
+import { cn, overlayPortalContainer } from "@repo/ui/lib/utils";
 import { Check, ChevronRight, Circle } from "lucide-react";
 import type * as React from "react";
 
@@ -72,7 +72,7 @@ function MenubarSubTrigger({
 
 function MenubarSubContent({ className, ...props }: MenubarPrimitive.Popup.Props) {
 	return (
-		<MenubarPrimitive.Portal>
+		<MenubarPrimitive.Portal container={overlayPortalContainer}>
 			<MenubarPrimitive.Positioner
 				className="isolate z-50 outline-none"
 				align="start"
@@ -102,7 +102,7 @@ function MenubarContent({
 }: MenubarPrimitive.Popup.Props &
 	Pick<MenubarPrimitive.Positioner.Props, "align" | "alignOffset" | "side" | "sideOffset">) {
 	return (
-		<MenubarPrimitive.Portal>
+		<MenubarPrimitive.Portal container={overlayPortalContainer}>
 			<MenubarPrimitive.Positioner
 				className="isolate z-50 outline-none"
 				align={align}

--- a/packages/ui/src/components/navigation-menu.tsx
+++ b/packages/ui/src/components/navigation-menu.tsx
@@ -1,5 +1,5 @@
 import { NavigationMenu as NavigationMenuPrimitive } from "@base-ui/react/navigation-menu";
-import { cn } from "@repo/ui/lib/utils";
+import { cn, overlayPortalContainer } from "@repo/ui/lib/utils";
 import { cva } from "class-variance-authority";
 import { ChevronDown } from "lucide-react";
 
@@ -58,7 +58,7 @@ const NavigationMenuLink = NavigationMenuPrimitive.Link;
 
 function NavigationMenuViewport({ className, ...props }: NavigationMenuPrimitive.Popup.Props) {
 	return (
-		<NavigationMenuPrimitive.Portal>
+		<NavigationMenuPrimitive.Portal container={overlayPortalContainer}>
 			<NavigationMenuPrimitive.Positioner className="isolate z-50" side="bottom" align="center" sideOffset={6}>
 				<NavigationMenuPrimitive.Popup
 					className={cn(

--- a/packages/ui/src/components/popover.tsx
+++ b/packages/ui/src/components/popover.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Popover as PopoverPrimitive } from "@base-ui/react/popover";
-import { cn } from "@repo/ui/lib/utils";
+import { cn, overlayPortalContainer } from "@repo/ui/lib/utils";
 import * as React from "react";
 
 const Popover = PopoverPrimitive.Root;
@@ -29,14 +29,7 @@ const PopoverContent = React.forwardRef<
 			"align" | "alignOffset" | "side" | "sideOffset" | "anchor"
 		>
 >(({ className, align = "center", alignOffset, side, sideOffset = 4, anchor, ...props }, ref) => (
-	// Base UI nests a Popover's portal inside the nearest ancestor Dialog's own
-	// portal by default (for focus-trap continuity) instead of `document.body`.
-	// A Dialog's Popup centers itself with a `translate` transform, which makes
-	// that ancestor a containing block for nested `position: fixed` descendants
-	// — trapping the Popover's stacking so it renders behind normal dialog
-	// content no matter its z-index. Force `document.body` (Base UI's own
-	// documented default) to escape that trap.
-	<PopoverPrimitive.Portal container={typeof document !== "undefined" ? document.body : undefined}>
+	<PopoverPrimitive.Portal container={overlayPortalContainer}>
 		<PopoverPrimitive.Positioner
 			align={align}
 			alignOffset={alignOffset}

--- a/packages/ui/src/components/select.tsx
+++ b/packages/ui/src/components/select.tsx
@@ -1,9 +1,8 @@
 "use client";
 
 import { Select as SelectPrimitive } from "@base-ui/react/select";
+import { cn, overlayPortalContainer } from "@repo/ui/lib/utils";
 import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react";
-
-import { cn } from "@repo/ui/lib/utils";
 
 const Select = SelectPrimitive.Root;
 
@@ -47,7 +46,7 @@ function SelectContent({
 	...props
 }: SelectPrimitive.Popup.Props & Pick<SelectPrimitive.Positioner.Props, "align" | "alignItemWithTrigger">) {
 	return (
-		<SelectPrimitive.Portal>
+		<SelectPrimitive.Portal container={overlayPortalContainer}>
 			<SelectPrimitive.Positioner className="isolate z-50" align={align} alignItemWithTrigger={alignItemWithTrigger}>
 				<SelectPrimitive.Popup
 					data-slot="select-content"

--- a/packages/ui/src/components/tooltip.tsx
+++ b/packages/ui/src/components/tooltip.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Tooltip as TooltipPrimitive } from "@base-ui/react/tooltip";
-import { cn } from "../lib/utils";
+import { cn, overlayPortalContainer } from "../lib/utils";
 
 function TooltipProvider({ delay = 0, ...props }: TooltipPrimitive.Provider.Props) {
 	return <TooltipPrimitive.Provider data-slot="tooltip-provider" delay={delay} {...props} />;
@@ -35,7 +35,7 @@ function TooltipContent({
 		// Dialog/panel's own portal by default, but a transform-centered ancestor
 		// (or the side panel drawer) becomes a containing block that traps the
 		// tooltip's position:fixed positioning behind normal page content.
-		<TooltipPrimitive.Portal container={typeof document !== "undefined" ? document.body : undefined}>
+		<TooltipPrimitive.Portal container={overlayPortalContainer}>
 			<TooltipPrimitive.Positioner
 				side={side}
 				sideOffset={sideOffset}

--- a/packages/ui/src/lib/utils.ts
+++ b/packages/ui/src/lib/utils.ts
@@ -5,6 +5,19 @@ export function cn(...inputs: ClassValue[]) {
 	return twMerge(clsx(inputs));
 }
 
+// Base UI nests a floating overlay's portal inside the nearest ancestor
+// overlay's own portal by default (for focus-trap continuity) instead of
+// `document.body`. A Dialog's Popup — or IndentDrawer's Popup, which uses the
+// same pattern — centers/translates itself with a transform, which makes
+// that ancestor a containing block for nested `position: fixed` descendants.
+// That traps a child overlay's stacking so it renders behind (or gets
+// clipped by) the ancestor no matter its own z-index. Passing this as every
+// floating overlay's `Portal container` forces Base UI's own documented
+// default and escapes that trap. Without it: a Select/DropdownMenu/etc. used
+// as a side panel's (IndentDrawer) content silently fails to render its
+// popup on top of the panel — it opens, but visually behind it.
+export const overlayPortalContainer = typeof document !== "undefined" ? document.body : undefined;
+
 export const normalizeUrl = (url: string): string => {
 	// If URL doesn't start with a protocol, add https://
 	if (!url.match(/^[a-zA-Z][a-zA-Z\d+\-.]*:/)) {


### PR DESCRIPTION
## What happened

The last two merges both got misclassified by `release-on-merge.yml`:

| PR | Intended | Actual | Why |
|---|---|---|---|
| #314 | `release:patch` → `v0.5.1` | `v0.6.0` (minor) | also had `cli-release:minor` |
| #315 | `release:skip` → no release | `v0.7.0` (minor) | also had `cli-release:minor` |

Both incorrectly triggered a full backend/worker/start build-and-deploy that shouldn't have run for #315 at all, and ran the wrong scope for #314.

## Root cause

`release-on-merge.yml`'s label detection uses unanchored `grep -q "release:minor"`, which matches as a **substring** — `cli-release:minor` contains `release:minor`. Since the `elif` chain checks major → minor → patch → skip in that order, any PR carrying a `cli-release:*` label gets misclassified before it can reach its actual `release:*` label.

`publish-cli.yml` already avoids this for its own `cli-release:*` checks by anchoring on the JSON-array quote (`grep -q '"cli-release:major"'`). `release-on-merge.yml` just never got the same treatment for its `release:*` checks.

## Fix

Quote each pattern the same way: `grep -q '"release:major"'`, etc. — matches the literal JSON-array entry, not a substring.

Doesn't touch the accidental `v0.6.0`/`v0.7.0` tags or their triggered deploys — flagging those as a separate decision for whoever wants to look at cleanup, not bundling it into this fix.