### PR TITLE
CLI: surface the real cause of network fetch failures

### DIFF
--- a/packages/cli/src/lib/client.ts
+++ b/packages/cli/src/lib/client.ts
@@ -9,6 +9,34 @@ import { DEFAULT_BASE_URL, readConfig } from "./config";
  */
 const ME_PREFIX = "/api/public/v1/me";
 
+// Node's fetch (undici) throws a generic `TypeError: fetch failed` for every
+// connection-level failure — the actual reason (a corporate TLS-inspecting
+// proxy's untrusted cert, a system proxy Node's fetch doesn't pick up the way
+// a browser does, DNS, a dropped connection, ...) is nested on `.cause`
+// (sometimes an AggregateError with its own `.errors`) and gets silently
+// dropped if only `err.message` is shown. That's the exact dead end reported
+// in practice: "Failed to reach https://api.sayr.io (fetch failed)" with no
+// way to tell a proxy/cert issue from anything else.
+function describeFetchError(err: unknown): string {
+	if (!(err instanceof Error)) return String(err);
+	const parts = [err.message];
+	let cause: unknown = err.cause;
+	while (cause) {
+		if (cause instanceof AggregateError) {
+			parts.push(...cause.errors.map((e) => (e instanceof Error ? e.message : String(e))));
+			break;
+		}
+		if (cause instanceof Error) {
+			parts.push(cause.message);
+			cause = cause.cause;
+		} else {
+			parts.push(String(cause));
+			break;
+		}
+	}
+	return [...new Set(parts)].join(" — caused by: ");
+}
+
 export class ApiClientError extends Error {
 	readonly code: string;
 	readonly status: number;
@@ -80,11 +108,7 @@ async function rawRequest<T>(path: string, opts: RequestInput): Promise<ApiSucce
 			body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined,
 		});
 	} catch (err) {
-		throw new ApiClientError(
-			"NETWORK_ERROR",
-			`Failed to reach ${baseUrl} (${err instanceof Error ? err.message : String(err)})`,
-			0
-		);
+		throw new ApiClientError("NETWORK_ERROR", `Failed to reach ${baseUrl} (${describeFetchError(err)})`, 0);
 	}
 
 	let json: ApiSuccessEnvelope<T> | ApiErrorEnvelope;


### PR DESCRIPTION
## Context

Trent (cofounder) is hitting `sayr login`/`sayr whoami` failing on Windows with:
```
✗ Failed to reach https://api.sayr.io (fetch failed)
```
even though `sayr config get` shows the right `baseUrl`, and the same URL + token works fine from a browser/Postman (200 OK). That rules out the API/token/config being wrong — it's something failing specifically inside Node's own network stack on his machine (common culprits on Windows: a corporate/antivirus TLS-inspecting proxy whose root CA isn't in Node's trust store even though it's in Windows'/the browser's, a system proxy Node's `fetch` doesn't pick up automatically the way a browser does, or a DNS/connectivity quirk).

## The actual bug

Node's `fetch` (undici) throws a generic `TypeError: fetch failed` for **every** connection-level failure — the real reason lives on `err.cause` (sometimes an `AggregateError` with its own `.errors`), and `rawRequest`'s catch block was only reading `err.message`, discarding it entirely. That's why the error is a dead end with no way to tell what's actually wrong.

## Fix

`describeFetchError()` walks the cause chain and folds it into the message. Verified locally:
```
✗ Failed to reach https://nonexistent-host.invalid (fetch failed — caused by: getaddrinfo ENOTFOUND nonexistent-host.invalid)
✗ Failed to reach https://expired.badssl.com (fetch failed — caused by: certificate has expired)
```

This won't fix whatever's actually wrong on Trent's machine, but the next time he runs the CLI it'll tell us exactly what to fix instead of guessing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved network error messages by including relevant details from nested and combined connection failures.
  * Removed duplicate information from expanded error diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->