### PR TITLE
Fix Zerops deploy workflow never triggering on release

### DIFF
--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -131,3 +131,14 @@ jobs:
     secrets: inherit
     with:
       version: ${{ needs.release.outputs.version }}
+
+  trigger-zerops-deploy:
+    name: Trigger Zerops Deploy
+    needs: release
+    if: needs.release.outputs.released == 'true'
+    # Invoked directly rather than relying on zerops-deploy.yml's own
+    # push.tags trigger: the tag above was pushed with GITHUB_TOKEN, and
+    # GitHub doesn't fire downstream workflows from GITHUB_TOKEN-authored
+    # pushes. Same reasoning as trigger-build above.
+    uses: ./.github/workflows/zerops-deploy.yml
+    secrets: inherit

--- a/.github/workflows/zerops-deploy.yml
+++ b/.github/workflows/zerops-deploy.yml
@@ -8,6 +8,15 @@
 # a digit, so cli-v* tags never match) and streams the Zerops build/deploy
 # log straight into the job output.
 #
+# The push.tags trigger only fires for a tag pushed with real user
+# credentials — release-on-merge.yml pushes its v* tag using the default
+# GITHUB_TOKEN, and GitHub deliberately suppresses downstream workflow
+# triggers from GITHUB_TOKEN-authored pushes (anti-recursion guard), so that
+# tag alone never reaches this workflow. The workflow_call trigger below is
+# what actually fires on a real release — release-on-merge.yml invokes this
+# workflow directly as a job, the same way it already does for
+# build-and-deploy.yml.
+#
 # Separate from build-and-deploy.yml, which builds the CE/self-host Docker
 # images for ghcr.io and has no relation to the Zerops project.
 #
@@ -34,6 +43,9 @@ on:
   push:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
+  # Invoked directly by release-on-merge.yml right after it tags a release —
+  # see the header comment above for why the tag push alone can't do this.
+  workflow_call: {}
   workflow_dispatch:
     inputs:
       marketing:
@@ -76,7 +88,7 @@ permissions:
 jobs:
   marketing:
     name: Deploy marketing
-    if: github.event_name == 'push' || inputs.marketing
+    if: github.event_name != 'workflow_dispatch' || inputs.marketing
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -87,7 +99,7 @@ jobs:
 
   backend:
     name: Deploy backend
-    if: github.event_name == 'push' || inputs.backend
+    if: github.event_name != 'workflow_dispatch' || inputs.backend
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -98,7 +110,7 @@ jobs:
 
   start:
     name: Deploy start
-    if: github.event_name == 'push' || inputs.start
+    if: github.event_name != 'workflow_dispatch' || inputs.start
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -109,7 +121,7 @@ jobs:
 
   workermain:
     name: Deploy workermain
-    if: github.event_name == 'push' || inputs.workermain
+    if: github.event_name != 'workflow_dispatch' || inputs.workermain
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -120,7 +132,7 @@ jobs:
 
   workergithub:
     name: Deploy workergithub
-    if: github.event_name == 'push' || inputs.workergithub
+    if: github.event_name != 'workflow_dispatch' || inputs.workergithub
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -131,7 +143,7 @@ jobs:
 
   integrations:
     name: Deploy integrations
-    if: github.event_name == 'push' || inputs.integrations
+    if: github.event_name != 'workflow_dispatch' || inputs.integrations
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
## Problem

`zerops-deploy.yml` (#320) never ran after merging — PR #320 itself merged, tagged `v0.5.3`, and the tag push visibly succeeded in the `release-on-merge.yml` run log, but `Deploy to Zerops` has zero runs in Actions history.

## Root cause

`release-on-merge.yml` pushes the release tag using the default `GITHUB_TOKEN`. GitHub deliberately suppresses downstream workflow triggers from `GITHUB_TOKEN`-authored pushes (an anti-recursion guard), so `zerops-deploy.yml`'s `push.tags` trigger structurally cannot fire from that tag, regardless of how correct the tag pattern is.

This is exactly the same restriction the existing CE Docker build already works around — `build-and-deploy.yml` isn't triggered by the tag push either; `release-on-merge.yml` invokes it directly as a `workflow_call` job (`trigger-build`).

## Fix

- Added a `workflow_call` trigger to `zerops-deploy.yml`.
- Added a `trigger-zerops-deploy` job to `release-on-merge.yml` that invokes it directly via `uses: ./.github/workflows/zerops-deploy.yml`, mirroring `trigger-build` exactly.
- Left `push.tags` and `workflow_dispatch` in place on `zerops-deploy.yml` for a manually-pushed tag (real user credentials, not `GITHUB_TOKEN`) or an ad hoc redeploy — only the automatic release path needed the new invocation route.
- Per-service `if:` conditions changed from `github.event_name == 'push' || inputs.X` to `github.event_name != 'workflow_dispatch' || inputs.X`, since a `workflow_call` invocation isn't a `push` event — the per-service checkboxes now only apply when someone runs the workflow manually via `workflow_dispatch`; both `push` and `workflow_call` always deploy all six services.

## Still required (unchanged from #320)

The `ZEROPS_TOKEN` + six `ZEROPS_SERVICE_ID_*` secrets still need to be added in GitHub, and the Zerops dashboard's per-service "automatic build trigger" still needs disabling, before this can actually deploy anything.